### PR TITLE
Rename AWS cloud_access to hourly

### DIFF
--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -20,8 +20,8 @@ def get_aws_regions() -> list[str]:
     return [x["RegionName"] for x in raw["Regions"]]
 
 
-def get_aws_cloud_access_images(region: str) -> list[str]:
-    """Get a list of RHEL cloud access images from an AWS region.
+def get_aws_hourly_images(region: str) -> list[str]:
+    """Get a list of RHEL hourly images from an AWS region.
 
     Args:
         region: AWS region name, such as "us-east-1"

--- a/tests/test_update_images.py
+++ b/tests/test_update_images.py
@@ -15,10 +15,10 @@ def test_get_aws_regions() -> None:
     boto.assert_called_with("DescribeRegions", {"AllRegions": "True"})
 
 
-def test_get_aws_cloud_access_images() -> None:
+def test_get_aws_hourly_images() -> None:
     """Test AWS image request."""
     with patch("botocore.client.BaseClient._make_api_call") as boto:
-        update_images.get_aws_cloud_access_images("us-east-1")
+        update_images.get_aws_hourly_images("us-east-1")
 
     boto.assert_called_with(
         "DescribeImages", {"IncludeDeprecated": "False", "Owners": ["309956199498"]}


### PR DESCRIPTION
I thought these were cloud access images originally, but they're actually hourly ones. Marketplace offers use different AMI IDs.

We should aim to match what appears here:

  https://access.redhat.com/solutions/15356

Signed-off-by: Major Hayden <major@mhtx.net>