### PR TITLE
Refactor AWS images for hourly/cloudaccess

### DIFF
--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -32,7 +32,7 @@ def aws_hourly_images(region: str) -> None:
         message += "\n  ".join(valid_regions)
         raise click.UsageError(message)
 
-    images = update_images.get_aws_hourly_images(region)
+    images = update_images.get_aws_images(region)
     click.echo(json.dumps(images, indent=2))
 
 

--- a/src/rhelocator/config.py
+++ b/src/rhelocator/config.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 import os
 
 
+# AWS
+# UsageOperation is the AWS method for tagging an image with a billing code.
+# RunInstances:0010 is for hourly images (customer pays cloud provider)
+# RunInstances:0000 is for cloud access images (customer gets sub from Red Hat)
+AWS_HOURLY_BILLING_CODE = "RunInstances:0010"
+AWS_CLOUD_ACCESS_BILLING_CODE = "RunInstances:0000"
+
 # AZURE AUTHENTICATION
 AZURE_CLIENT_ID = os.environ.get("AZURE_CLIENT_ID", None)
 AZURE_CLIENT_SECRET = os.environ.get("AZURE_CLIENT_SECRET", None)

--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -22,7 +22,7 @@ def get_aws_regions() -> list[str]:
     return sorted([x["RegionName"] for x in raw["Regions"]])
 
 
-def aws_describe_images(region: str) -> list[str]:
+def aws_describe_images(region: str) -> list[dict[str, str]]:
     """Make an API call to AWS to get a list of RHEL images in a region.
 
     Args:
@@ -33,10 +33,10 @@ def aws_describe_images(region: str) -> list[str]:
     """
     ec2 = boto3.client("ec2", region_name=region)
     raw = ec2.describe_images(Owners=["309956199498"], IncludeDeprecated=False)
-    return raw["Images"]
+    return list(raw["Images"])
 
 
-def get_aws_images(region: str, image_type: str = "hourly") -> list[str]:
+def get_aws_images(region: str, image_type: str = "hourly") -> list[dict[str, str]]:
     """Get a list of RHEL hourly images from an AWS region.
 
     Args:
@@ -60,7 +60,7 @@ def get_aws_images(region: str, image_type: str = "hourly") -> list[str]:
     return [x for x in images if x["UsageOperation"] == billing_code]
 
 
-def get_aws_all_images(image_type: str = "hourly") -> dict[str, list[str]]:
+def get_aws_all_images(image_type: str = "hourly") -> dict[str, list[dict[str, str]]]:
     """Retrieve all RHEL images from all regions."""
     regions = get_aws_regions()
     images_per_region = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 MOCKED_AWS_IMAGE_LIST = [
     {"ImageId": "ami-0001", "UsageOperation": "RunInstances:0010"},
     {"ImageId": "ami-0002", "UsageOperation": "RunInstances:0010"},
-    {"ImageId": "ami-0003", "UsageOperation": "RunInstances:0010"},
+    {"ImageId": "ami-0003", "UsageOperation": "RunInstances:0000"},
 ]
 
 
@@ -24,8 +24,8 @@ def mock_aws_regions(mocker):
 
 
 @pytest.fixture
-def mock_aws_hourly_images(mocker):
-    """Provide an offline result for calls to get_aws_hourly_images."""
-    mock = mocker.patch("rhelocator.update_images.get_aws_hourly_images")
+def mock_aws_images(mocker):
+    """Provide an offline result for calls to get_aws_images."""
+    mock = mocker.patch("rhelocator.update_images.aws_describe_images")
     mock.return_value = MOCKED_AWS_IMAGE_LIST
     return mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import click.testing
 import pytest
 
 from rhelocator import cli
+from rhelocator import config
 
 
 @pytest.fixture
@@ -21,17 +22,17 @@ def test_aws_hourly_images_live(runner):
     parsed = json.loads(result.output)
 
     # Ensure we only received hourly images with the proper billing code.
-    assert {x["UsageOperation"] for x in parsed} == {"RunInstances:0010"}
+    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
     assert result.exit_code == 0
 
 
-def test_aws_hourly_images_offline(runner, mock_aws_regions, mock_aws_hourly_images):
+def test_aws_hourly_images_offline(runner, mock_aws_regions, mock_aws_images):
     """Run an offline test against the AWS API to get hourly images via CLI."""
     result = runner.invoke(cli.aws_hourly_images, ["--region=us-east-1"])
     parsed = json.loads(result.output)
 
     # Ensure we only received hourly images with the proper billing code.
-    assert {x["UsageOperation"] for x in parsed} == {"RunInstances:0010"}
+    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
Update pytest fixtures to include cloud access billing codes and use
those fixtures consistently. Add the billing codes to config and use the
constants consistently.

Split out the actual AWS describe_image call into its own function for
easier mocking and testing. Add an argument to get_aws_images that
specifies which image types to filter for with hourly as the default.

Fixes: #7                                                               