### PR TITLE
Make Azure functions call for access token

### DIFF
--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -69,18 +69,15 @@ def get_azure_access_token() -> str:
     return str(resp.json().get("access_token", None))
 
 
-def get_azure_locations(access_token: str) -> list[str]:
+def get_azure_locations() -> list[str]:
     """Get a list of all Azure locations.
 
-    Azure API docs:
-        https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list-locations?tabs=HTTP
-
-    Args:
-        access_token: Valid Azure access token from get_azure_access_token().
+    https://learn.microsoft.com/en-us/rest/api/resources/subscriptions/list-locations?tabs=HTTP
 
     Returns:
         List of valid Azure regions.
     """
+    access_token = get_azure_access_token()
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"api-version": "2020-01-01"}
     url = (


### PR DESCRIPTION
A consumer of the Azure image/location functions shouldn't need to know about calling the function to get an access_token. Let the Azure functions request an access token as part of their existing work.

Fixes: #12

Signed-off-by: Major Hayden <major@redhat.com>