### PR TITLE
Add code release workflow

### DIFF
--- a/.github/workflows/code_release.yaml
+++ b/.github/workflows/code_release.yaml
@@ -1,0 +1,40 @@
+# Based on https://github.com/python-poetry/poetry/blob/master/.github/workflows/release.yml
+
+name: Code-Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  prep:
+    name: Code Release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Bootstrap poetry
+        run: |
+          curl -sL https://install.python-poetry.org | python - -y
+
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build project for distribution
+        run: poetry build
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false


### PR DESCRIPTION
This workflow is rather simple and the basis for the container_release workflow.

The code base is build and released under the version tag.
The follow up workflow takes the most recently released version, installs and uses the CLI tools to create the image data json files which are baked into the container image.

Partly fixes: #6 