### PR TITLE
Move hardcoded AWS OwnerId to config

### DIFF
--- a/src/rhelocator/config.py
+++ b/src/rhelocator/config.py
@@ -10,6 +10,8 @@ import os
 # RunInstances:0000 is for cloud access images (customer gets sub from Red Hat)
 AWS_HOURLY_BILLING_CODE = "RunInstances:0010"
 AWS_CLOUD_ACCESS_BILLING_CODE = "RunInstances:0000"
+# RHEL's OwnerId for RHEL images in AWS is 309956199498.
+AWS_RHEL_OWNER_ID = "309956199498"
 
 # AZURE AUTHENTICATION
 AZURE_CLIENT_ID = os.environ.get("AZURE_CLIENT_ID", None)

--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -32,7 +32,9 @@ def aws_describe_images(region: str) -> list[dict[str, str]]:
         List of dictionaries containing image data.
     """
     ec2 = boto3.client("ec2", region_name=region)
-    raw = ec2.describe_images(Owners=["309956199498"], IncludeDeprecated=False)
+    raw = ec2.describe_images(
+        Owners=[config.AWS_RHEL_OWNER_ID], IncludeDeprecated=False
+    )
     return list(raw["Images"])
 
 

--- a/tests/test_update_images.py
+++ b/tests/test_update_images.py
@@ -25,7 +25,8 @@ def test_aws_describe_images() -> None:
         update_images.aws_describe_images("us-east-1")
 
     boto.assert_called_with(
-        "DescribeImages", {"IncludeDeprecated": False, "Owners": ["309956199498"]}
+        "DescribeImages",
+        {"IncludeDeprecated": False, "Owners": [config.AWS_RHEL_OWNER_ID]},
     )
 
 


### PR DESCRIPTION
This makes it easier to update the OwnerId later if needed.

Fixes: #9

Signed-off-by: Major Hayden <major@redhat.com>