### PR TITLE
remove hardcoded project name

### DIFF
--- a/src/rhelocator/config.py
+++ b/src/rhelocator/config.py
@@ -45,5 +45,11 @@ AZURE_RHEL_IMAGE_TREE = {
     }
 }
 
-# GCP
+#    ________________ 
+#   / ____/ ____/ __ \
+#  / / __/ /   / /_/ /
+# / /_/ / /___/ ____/ 
+# \____/\____/_/ 
+
+# Defines project name.
 GCP_PROJECTNAME = "rhel-cloud"

--- a/src/rhelocator/config.py
+++ b/src/rhelocator/config.py
@@ -44,3 +44,6 @@ AZURE_RHEL_IMAGE_TREE = {
         "RHEL": {"7lvm-gen2": "latest", "8-lvm-gen2": "latest", "9-lvm-gen2": "latest"}
     }
 }
+
+# GCP
+GCP_PROJECTNAME = "rhel-cloud"

--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -261,7 +261,7 @@ def get_google_images() -> list[str]:
     # NOTE(mhayden): Google's examples suggest using a filter here for "deprecated.state
     # != DEPRECATED" but it returns no images when I tried it.
     # https://github.com/googleapis/python-compute/blob/main/samples/recipes/images/pagination.py
-    images_list_request = compute_v1.ListImagesRequest(project="rhel-cloud")
+    images_list_request = compute_v1.ListImagesRequest(project=config.GCP_PROJECTNAME)
 
     return [
         x.name


### PR DESCRIPTION
Hey, now `GCP_PROJECTNAME` is hardcoded in `config.py`, should it be an environment variable instead? :)
And do you have any idea, why the CI-pipeline fails? It also fails without a diff^^ :D 

Closes #19 

cc @major @FKolwa 