### PR TITLE
Remove LRU cache for get_azure_access_token

### DIFF
--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -1,8 +1,6 @@
 """Update images from public cloud APIs."""
 from __future__ import annotations
 
-import functools
-
 import boto3
 import requests
 
@@ -73,7 +71,6 @@ def get_aws_all_images(image_type: str = "hourly") -> dict[str, list[dict[str, s
     return images_per_region
 
 
-@functools.lru_cache
 def get_azure_access_token() -> str:
     """Authenticate with Azure and return the access token to use with API requests.
 


### PR DESCRIPTION
This caused issues with randomly ordered tests since the cached result conflicted with the values passed in by mocks. We can investigate this later if it becomes a problem.

Fixes #25

Signed-off-by: Major Hayden <major@redhat.com>