### PR TITLE
Disable live tests on PR from fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,11 +78,16 @@ jobs:
       - name: Install pytest plugin
         run: poetry run pip install pytest-github-actions-annotate-failures
 
-      - name: Run pytest
+      - name: Run pytest with live e2e tests
+        if: ${{ github.repository_owner == 'redhatcloudx' }}
         run: poetry run python -m pytest -n auto -p no:sugar -q tests/
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Run pytest with offline tests only
+        if: ${{ github.repository_owner != 'redhatcloudx' }}
+        run: poetry run python -m pytest -m "not e2e -n auto -p no:sugar -q tests/
 
       - name: Check for clean working tree
         run: |


### PR DESCRIPTION
PRs from forks won't use our GitHub Actions secrets, so only run the offline tests for those. We need to come up with a better method to handle this.

Fixes: #21 

Signed-off-by: Major Hayden <major@redhat.com>