### PR TITLE
Skip e2e tests on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,15 +79,17 @@ jobs:
         run: poetry run pip install pytest-github-actions-annotate-failures
 
       - name: Run pytest with live e2e tests
-        if: ${{ github.repository_owner == 'redhatcloudx' }}
+        if: env.AWS_ACCESS_KEY_ID != null
         run: poetry run python -m pytest -n auto -p no:sugar -q tests/
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Run pytest with offline tests only
-        if: ${{ github.repository_owner != 'redhatcloudx' }}
-        run: poetry run python -m pytest -m "not e2e -n auto -p no:sugar -q tests/
+        if: env.SECRET_CHECK == null
+        run: poetry run python -m pytest -m "not e2e" -n auto -p no:sugar -q tests/
+        env:
+          SECRET_CHECK: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
       - name: Check for clean working tree
         run: |


### PR DESCRIPTION
Skipping e2e tests if secrets are unavailable.

why?
github.repository_owner seems to resolve to redhatcloudx even on forks
if: ${{ github.repository_owner == 'redhatcloudx' }} will always succeed even if owner is not redhatcloudx:
https://github.com/actions/runner/issues/1173