### PR TITLE
add gcp image list command to CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,8 +88,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          GCP_APP_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
-
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
 
       - name: Run pytest with offline tests only
         if: env.SECRET_CHECK == null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,8 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          GCP_APP_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+
 
       - name: Run pytest with offline tests only
         if: env.SECRET_CHECK == null

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -42,6 +42,11 @@ def aws_regions() -> None:
     regions = update_images.get_aws_regions()
     click.echo(json.dumps(regions, indent=2))
 
+@click.command()
+def gcp_images() -> None:
+    """Dump GCP images for all regions in JSON format"""
+    images = update_images.get_google_images()
+    click.echo(json.dumps(images, indent=2))
 
 @click.command()
 def azure_images() -> None:
@@ -53,3 +58,4 @@ def azure_images() -> None:
 cli.add_command(aws_hourly_images)
 cli.add_command(aws_regions)
 cli.add_command(azure_images)
+cli.add_command(gcp_images)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ MOCKED_AZURE_IMAGE_VERSION_LIST = [
     "9.0.2022090601",
 ]
 
+MOCKED_GCP_IMAGE_LIST = [
+    {"status": "READY"},
+    {"status": "DEPRICATED"},
+]
+
 
 def pytest_configure(config: any) -> None:
     config.addinivalue_line("markers", "e2e: mark as end-to-end test.")
@@ -52,4 +57,12 @@ def mock_azure_image_versions_latest(mocker):
     """Provide an offline result got get_azure_image_versions."""
     mock = mocker.patch("rhelocator.update_images.get_azure_image_versions")
     mock.return_value = [MOCKED_AZURE_IMAGE_VERSION_LIST[0]]
+    return mock
+
+
+@pytest.fixture
+def mock_gcp_images(mocker):
+    """Provide an offline result for calls to get_google_images."""
+    mock = mocker.patch("rhelocator.update_images.get_google_images")
+    mock.return_value = MOCKED_GCP_IMAGE_LIST
     return mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ MOCKED_AZURE_IMAGE_VERSION_LIST = [
 
 MOCKED_GCP_IMAGE_LIST = [
     {"status": "READY"},
-    {"status": "DEPRICATED"},
+    {"status": "DEPRECATED"},
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,6 @@ def test_aws_regions_offline(mock_aws_regions, runner):
     assert "us-east-1" in parsed
     assert result.exit_code == 0
 
-
 @pytest.mark.e2e
 def test_azure_images_live(runner):
     """Run a live test against the Azure API to get images via CLI."""
@@ -113,5 +112,29 @@ def test_azure_images_offline(mock_azure_image_versions, runner):
     for image in parsed:
         expected_keys = ["offer", "publisher", "sku", "urn", "version"]
         assert list(image.keys()) == expected_keys
+
+    assert result.exit_code == 0
+
+@pytest.mark.e2e
+def test_gcp_images_live(runner):
+    """Run a live test against the Google Cloud API to get images via CLI."""
+    result = runner.invoke(cli.gcp_images)
+    parsed = json.loads(result.output)
+
+    assert isinstance(parsed, list)
+
+    assert {image["status"] for image in parsed} != "DEPRICATED"
+
+    assert result.exit_code == 0
+
+
+def test_gcp_images_offline(mock_gcp_images, runner):
+    """Run a live test against the Google Cloud API to get images via CLI."""
+    result = runner.invoke(cli.gcp_images)
+    parsed = json.loads(result.output)
+
+    assert isinstance(parsed, list)
+
+    assert {image["status"] for image in parsed} != "DEPRICATED"
 
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,7 +123,7 @@ def test_gcp_images_live(runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRICATED"
+    assert {image["status"] for image in parsed} != "DEPRECATED"
 
     assert result.exit_code == 0
 
@@ -135,6 +135,6 @@ def test_gcp_images_offline(mock_gcp_images, runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRICATED"
+    assert {image["status"] for image in parsed} != "DEPRECATED"
 
     assert result.exit_code == 0


### PR DESCRIPTION
Hey @major @FKolwa ,

I am a bit confused right now. We assign the registered github secret `secrets.GOOGLE_APPLICATION_CREDENTIALS` to an environment variable `GCP_APP_CREDENTIALS`, but we never use it. 

In the `get_google_images` function we create an `compute_v1.ImagesClient` client, is he supposed to use those credentials? 

I went to the [google docs](https://cloud.google.com/python/docs/reference/compute/latest/google.cloud.compute_v1.services.instances.InstancesClient#google_cloud_compute_v1_services_instances_InstancesClient_aggregated_list), but it also didn't really helped me. :) 

Can you give me some hints? :sweat_smile: 

closes #17 