### PR TITLE
Filter out opt-in AWS regions temporarily

### DIFF
--- a/src/rhelocator/update_images.py
+++ b/src/rhelocator/update_images.py
@@ -18,7 +18,15 @@ def get_aws_regions() -> list[str]:
         List of AWS regions as strings.
     """
     ec2 = boto3.client("ec2", region_name="us-east-1")
-    raw = ec2.describe_regions(AllRegions=True)
+    # TODO(mhayden): Remove the opt-in-status filter below once AWS enables the
+    #  additional regions for the account. The opt-in was requested on 2022-10-11 but
+    #  it could take time before they are enabled.
+    raw = ec2.describe_regions(
+        Filters=[
+            {"Name": "opt-in-status", "Values": ["opt-in-not-required", "opted-in"]}
+        ],
+        AllRegions=True,
+    )
     return sorted([x["RegionName"] for x in raw["Regions"]])
 
 

--- a/tests/test_update_images.py
+++ b/tests/test_update_images.py
@@ -16,7 +16,15 @@ def test_get_aws_regions() -> None:
     with patch("botocore.client.BaseClient._make_api_call") as boto:
         update_images.get_aws_regions()
 
-    boto.assert_called_with("DescribeRegions", {"AllRegions": True})
+    boto.assert_called_with(
+        "DescribeRegions",
+        {
+            "AllRegions": True,
+            "Filters": [
+                {"Name": "opt-in-status", "Values": ["opt-in-not-required", "opted-in"]}
+            ],
+        },
+    )
 
 
 def test_aws_describe_images() -> None:


### PR DESCRIPTION
Some regions require an opt-in step and that causes the image listings to fail in those regions. I've requested access to these regions in my account but that request can take a few minutes to a few days.

We can revert this as soon as the opt-in process finishes.

Signed-off-by: Major Hayden <major@redhat.com>