### PR TITLE
Add e2e AWS test for opt-in region

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,20 @@ def runner():
 
 
 @pytest.mark.e2e
+def test_aws_hourly_images_live_opt_in_region(runner):
+    """Run a live test against the AWS API to get hourly images for opt-in regions.
+
+    Further reading: https://github.com/redhatcloudx/rhelocator/issues/43
+    """
+    result = runner.invoke(cli.aws_hourly_images, ["--region=af-south-1"])
+    parsed = json.loads(result.output)
+
+    # Ensure we only received hourly images with the proper billing code.
+    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
+    assert result.exit_code == 0
+
+
+@pytest.mark.e2e
 def test_aws_hourly_images_live(runner):
     """Run a live test against the AWS API to get hourly images via CLI."""
     result = runner.invoke(cli.aws_hourly_images, ["--region=us-east-1"])


### PR DESCRIPTION
AWS requires an opt-in process for certain regions and this may cause regions to be returned from a `describe_regions()` call that cannot be used along with a `describe_images()` call until the opt-in process is complete.

Fixes #43

Signed-off-by: Major Hayden <major@redhat.com>