### PR TITLE
Dump Google credentials to file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,11 @@ jobs:
       - name: Install pytest plugin
         run: poetry run pip install pytest-github-actions-annotate-failures
 
+      - name: Dump Google credentials to a temporary file
+        run: echo $GOOGLE_APPLICATION_CREDENTIALS >> /tmp/google-creds.json
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+
       - name: Run pytest with live e2e tests
         if: env.AWS_ACCESS_KEY_ID != null
         run: poetry run python -m pytest -n auto -p no:sugar -q tests/
@@ -88,7 +93,10 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/google-creds.json
+
+      - name: Remove Google credentials
+        run: rm -f /tmp/google-creds.json
 
       - name: Run pytest with offline tests only
         if: env.SECRET_CHECK == null

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,10 @@ MOCKED_AZURE_IMAGE_VERSION_LIST = [
 ]
 
 MOCKED_GCP_IMAGE_LIST = [
-    {"status": "READY"},
-    {"status": "DEPRECATED"},
+    "rhel-7-v20220920",
+    "rhel-8-v20220920",
+    "rhel-9-arm64-v20220920",
+    "rhel-9-v20220920",
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,7 @@ def test_aws_regions_offline(mock_aws_regions, runner):
     assert "us-east-1" in parsed
     assert result.exit_code == 0
 
+
 @pytest.mark.e2e
 def test_azure_images_live(runner):
     """Run a live test against the Azure API to get images via CLI."""
@@ -115,6 +116,7 @@ def test_azure_images_offline(mock_azure_image_versions, runner):
 
     assert result.exit_code == 0
 
+
 @pytest.mark.e2e
 def test_gcp_images_live(runner):
     """Run a live test against the Google Cloud API to get images via CLI."""
@@ -123,7 +125,8 @@ def test_gcp_images_live(runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRECATED"
+    for image in parsed:
+        assert image.startswith("rhel")
 
     assert result.exit_code == 0
 
@@ -135,6 +138,7 @@ def test_gcp_images_offline(mock_gcp_images, runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRECATED"
+    for image in parsed:
+        assert image.startswith("rhel")
 
     assert result.exit_code == 0


### PR DESCRIPTION
It looks like Google's SDK looks for credentials as a file location only, and not as a JSON string. We need to write it to the filesystem temporarily to use it.

Signed-off-by: Major Hayden <major@redhat.com>