### PR TITLE
Add Google Auth to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -88,7 +94,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+          GOOGLE_APPLICATION_CREDENTIALS: '${{ steps.auth.outputs.credentials_file_path }}'
 
       - name: Run pytest with offline tests only
         if: env.SECRET_CHECK == null

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Google generated token and credentials
+gha-creds*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,10 @@ MOCKED_AZURE_IMAGE_VERSION_LIST = [
 ]
 
 MOCKED_GCP_IMAGE_LIST = [
-    {"status": "READY"},
-    {"status": "DEPRECATED"},
+    "rhel-7-v20220920",
+    "rhel-8-v20220920",
+    "rhel-9-arm64-v20220920",
+    "rhel-9-v20220920",
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,7 @@ def test_aws_regions_offline(mock_aws_regions, runner):
     assert "us-east-1" in parsed
     assert result.exit_code == 0
 
+
 @pytest.mark.e2e
 def test_azure_images_live(runner):
     """Run a live test against the Azure API to get images via CLI."""
@@ -115,6 +116,7 @@ def test_azure_images_offline(mock_azure_image_versions, runner):
 
     assert result.exit_code == 0
 
+
 @pytest.mark.e2e
 def test_gcp_images_live(runner):
     """Run a live test against the Google Cloud API to get images via CLI."""
@@ -123,7 +125,8 @@ def test_gcp_images_live(runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRECATED"
+    for image in parsed:
+        assert image.startswith("rhel")
 
     assert result.exit_code == 0
 
@@ -135,6 +138,7 @@ def test_gcp_images_offline(mock_gcp_images, runner):
 
     assert isinstance(parsed, list)
 
-    assert {image["status"] for image in parsed} != "DEPRECATED"
+    for image in parsed:
+        assert image.startswith("rhel")
 
     assert result.exit_code == 0


### PR DESCRIPTION
This PR removes the need to dump the Google service credentials into a local file before running the e2e tests.
Github enabled [Open ID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers) last year.

In short:
We can use our credentials as secrets to authenticate with Google, return a one time token (1 hour validity) and use this token to run out API requests.
This PR uses the existing Google service account key to return this token but I will open up a follow up task to move to [Workload Identity Federation](https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions) instead.

Github supports OIDC for Azure, AWS and Google as well as external credential providers like HashiCorp's Valut so it might be worth to spend some time and setup a unified authentication system.