### PR TITLE
Write a credentials file for Google

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
+          create_credentials_file: 'true'
           credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The docs[0] require a temporary credentials file to be written so that it can be used later with `outputs.credentials_file_path`. The credentials are cleaned up in a post action automatically.

[0] https://github.com/google-github-actions/auth#other-inputs

Signed-off-by: Major Hayden <major@redhat.com>