### PR TITLE
Allow pre-commit.ci to automatically fix PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: false
+  autofix_prs: true
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -44,11 +44,13 @@ def aws_regions() -> None:
     regions = aws.get_regions()
     click.echo(json.dumps(regions, indent=2))
 
+
 @click.command()
 def gcp_images() -> None:
     """Dump GCP images for all regions in JSON format"""
     images = gcp.get_images()
     click.echo(json.dumps(images, indent=2))
+
 
 @click.command()
 def azure_images() -> None:

--- a/src/rhelocator/update_images/azure.py
+++ b/src/rhelocator/update_images/azure.py
@@ -184,4 +184,3 @@ def get_images() -> list[dict[str, str]]:
                     results.append(result)
 
     return results
-

--- a/src/rhelocator/update_images/gcp.py
+++ b/src/rhelocator/update_images/gcp.py
@@ -7,6 +7,7 @@ from google.cloud import compute_v1
 
 from rhelocator import config
 
+
 def get_images() -> list[dict[str, str]]:
     """Get a list of RHEL images from Google Cloud.
 

--- a/tests/update_images/test_aws.py
+++ b/tests/update_images/test_aws.py
@@ -1,8 +1,6 @@
 """Test image updates from remote cloud APIs."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest

--- a/tests/update_images/test_azure.py
+++ b/tests/update_images/test_azure.py
@@ -5,8 +5,6 @@ from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
-import pytest
-
 from rhelocator import config
 from rhelocator.update_images import azure
 
@@ -153,9 +151,7 @@ def test_get_image_versions(mock_get):
     mock_get.return_value.json.return_value = image_versions_response
 
     # Try with the default where we only get the latest image.
-    image_versions = azure.get_image_versions(
-        "eastus", "publisher", "offer", "sku"
-    )
+    image_versions = azure.get_image_versions("eastus", "publisher", "offer", "sku")
     assert image_versions == [image_versions_response[-1]["name"]]
 
     # Now try to get all of the images.
@@ -205,4 +201,3 @@ def test_get_all_images(mock_azure_image_versions):
     # Since we're looking for all image versions instead of just the latest ones, we
     # should have multiple image versions returned.
     assert len(images) == len(mock_azure_image_versions.return_value)
-


### PR DESCRIPTION
When we submit a commit that has linting issues, [pre-commit.ci](https://pre-commit.ci/) can automatically add a commit to the PR to fix any issues it finds. 🪄