### PR TITLE
Automatically format docstrings with docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,11 @@ repos:
       - id: pycln
         args: [--all]
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.5.0
+    hooks:
+      - id: docformatter
+
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -20,7 +20,7 @@ def cli() -> None:
 @click.command()
 @click.option("--region", help="AWS region to query (optional)", type=str)
 def aws_hourly_images(region: str) -> None:
-    """Dump AWS hourly images from a region in JSON format"""
+    """Dump AWS hourly images from a region in JSON format."""
     # Verify that the user provided a region.
     if not region:
         raise click.UsageError(
@@ -47,14 +47,14 @@ def aws_regions() -> None:
 
 @click.command()
 def gcp_images() -> None:
-    """Dump GCP images for all regions in JSON format"""
+    """Dump GCP images for all regions in JSON format."""
     images = gcp.get_images()
     click.echo(json.dumps(images, indent=2))
 
 
 @click.command()
 def azure_images() -> None:
-    """Dump Azure images from a region in JSON format"""
+    """Dump Azure images from a region in JSON format."""
     images = azure.get_images()
     click.echo(json.dumps(images, indent=2))
 

--- a/src/rhelocator/update_images/azure.py
+++ b/src/rhelocator/update_images/azure.py
@@ -7,7 +7,8 @@ from rhelocator import config
 
 
 def get_access_token() -> str:
-    """Authenticate with Azure and return the access token to use with API requests.
+    """Authenticate with Azure and return the access token to use with API
+    requests.
 
     Returns:
         Access token as a string.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,8 @@ def runner():
 
 @pytest.mark.e2e
 def test_aws_hourly_images_live_opt_in_region(runner):
-    """Run a live test against the AWS API to get hourly images for opt-in regions.
+    """Run a live test against the AWS API to get hourly images for opt-in
+    regions.
 
     Further reading: https://github.com/redhatcloudx/rhelocator/issues/43
     """
@@ -59,7 +60,8 @@ def test_aws_hourly_images_missing_region(runner):
 
 
 def test_aws_hourly_images_invalid_region(mock_aws_regions, runner):
-    """Simulate a failure to provide a valid region for the hourly images command."""
+    """Simulate a failure to provide a valid region for the hourly images
+    command."""
     result = runner.invoke(cli.aws_hourly_images, ["--region=antarctica-west-99"])
 
     assert "antarctica-west-99 is not valid" in result.output


### PR DESCRIPTION
The docformatter project automatically fixes docstrings to match [PEP 257](https://peps.python.org/pep-0257/) requirements.