### PR TITLE
pre-commit: Use defaults for isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,18 +66,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        name: "isort (python)"
         types: [python]
-        args: [--add-import, from __future__ import annotations]
-        exclude: |
-          (?x)(
-             ^(install|get)-poetry.py$
-              | ^src/poetry/__init__.py$
-          )
-      - id: isort
-        name: "isort (pyi)"
-        types: [pyi]
-        args: [--lines-after-imports, "-1"]
 
   - repo: https://github.com/psf/black
     rev: 22.10.0


### PR DESCRIPTION
Switch back to defaults for the isort tool to more closely align with Python's standards.

Signed-off-by: Major Hayden <major@redhat.com>