### PR TITLE
Switch to 3.11 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu]
-        python-version: ["3.9", "3.10", "3.11-dev"]
+        python-version: ["3.9", "3.10", "3.11"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04


### PR DESCRIPTION
Let's use the latest released version of 3.11 now that it went GA. 🐍