### PR TITLE
Convert AWS image data to schema approved format

### DIFF
--- a/src/rhelocator/update_images/schema.py
+++ b/src/rhelocator/update_images/schema.py
@@ -12,6 +12,7 @@ SCHEMA = {
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Human readable image name"},
+                "arch": {"type": "string", "description": "Architecture"},
                 "version": {
                     "type": "string",
                     "description": "RHEL image version following MAJOR.MINOR.PATCH",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,30 @@ import pytest
 
 
 MOCKED_AWS_IMAGE_LIST = [
-    {"ImageId": "ami-0001", "UsageOperation": "RunInstances:0010"},
-    {"ImageId": "ami-0002", "UsageOperation": "RunInstances:0010"},
-    {"ImageId": "ami-0003", "UsageOperation": "RunInstances:0000"},
+    {
+        "ImageId": "ami-0001",
+        "UsageOperation": "RunInstances:0010",
+        "Architecture": "x86_64",
+        "CreationDate": "2021-02-10T16:19:48.000Z",
+        "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+        "VirtualizationType": "hvm",
+    },
+    {
+        "ImageId": "ami-0002",
+        "UsageOperation": "RunInstances:0010",
+        "Architecture": "x86_64",
+        "CreationDate": "2021-02-10T16:19:48.000Z",
+        "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+        "VirtualizationType": "hvm",
+    },
+    {
+        "ImageId": "ami-0003",
+        "UsageOperation": "RunInstances:0000",
+        "Architecture": "x86_64",
+        "CreationDate": "2021-02-10T16:19:48.000Z",
+        "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+        "VirtualizationType": "hvm",
+    },
 ]
 
 MOCKED_AZURE_IMAGE_VERSION_LIST = [

--- a/tests/update_images/test_json_schema.py
+++ b/tests/update_images/test_json_schema.py
@@ -15,6 +15,7 @@ def test_valid_image_data_validation():
             "aws": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "date": "some date",
@@ -26,6 +27,7 @@ def test_valid_image_data_validation():
             "azure": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "date": "some date",
@@ -35,6 +37,7 @@ def test_valid_image_data_validation():
             "google": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "date": "some date",
@@ -58,6 +61,7 @@ def test_incomplete_image_data_validation():
             "aws": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "virt": "some virt",
@@ -79,6 +83,7 @@ def test_invalid_image_data_validation():
             "aws": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": False,
                     "imageId": "some id",
                     "virt": "some virt",
@@ -101,6 +106,7 @@ def test_invalid_extra_image_data_validation():
             "oracle": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "virt": "some virt",
@@ -125,6 +131,7 @@ def test_malicious_url():
             "aws": [
                 {
                     "name": "some name",
+                    "arch": "some arch",
                     "version": "some version",
                     "imageId": "some id",
                     "virt": "some virt",


### PR DESCRIPTION
- Add new function 'format_image' to convert individual images according to JSON schema.
- Add new function 'format_all_images' to retrieve and convert all images for all regions.

Additional changes:
- Add missing architecture property to JSON schema.