### PR TITLE
Add aws formatting to cli

### DIFF
--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -9,6 +9,7 @@ from rhelocator import __version__
 from rhelocator.update_images import aws
 from rhelocator.update_images import azure
 from rhelocator.update_images import gcp
+from rhelocator.update_images import schema
 
 
 @click.group()
@@ -26,6 +27,7 @@ def aws_hourly_images(region: str) -> None:
         raise click.UsageError(
             "Provide a valid AWS region with --region, such as 'us-east-1'"
         )
+    formatted_images: list[dict[str, str]] = []
 
     # Is this a valid region?
     valid_regions = aws.get_regions()
@@ -35,7 +37,10 @@ def aws_hourly_images(region: str) -> None:
         raise click.UsageError(message)
 
     images = aws.get_images(region)
-    click.echo(json.dumps(images, indent=2))
+    for image in images:
+        formatted_images.append(aws.format_image(image, region))
+
+    dump_images({"images": {"aws": formatted_images}})
 
 
 @click.command()
@@ -56,6 +61,12 @@ def gcp_images() -> None:
 def azure_images() -> None:
     """Dump Azure images from a region in JSON format."""
     images = azure.get_images()
+    click.echo(json.dumps(images, indent=2))
+
+
+def dump_images(images: object) -> None:
+    """Validate and dump image data in JSON format."""
+    schema.validate_json(images)
     click.echo(json.dumps(images, indent=2))
 
 

--- a/src/rhelocator/update_images/schema.py
+++ b/src/rhelocator/update_images/schema.py
@@ -93,7 +93,7 @@ SCHEMA = {
 }
 
 
-def validate_json(data: str) -> None:
+def validate_json(data: object) -> None:
     """Validate a JSON document against the schema.
 
     Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ MOCKED_AWS_IMAGE_LIST = [
         "UsageOperation": "RunInstances:0000",
         "Architecture": "x86_64",
         "CreationDate": "2021-02-10T16:19:48.000Z",
-        "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+        "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Access2-GP2",
         "VirtualizationType": "hvm",
     },
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import click.testing
 import pytest
 
 from rhelocator import cli
-from rhelocator import config
 
 
 @pytest.fixture
@@ -26,7 +25,7 @@ def test_aws_hourly_images_live_opt_in_region(runner):
     parsed = json.loads(result.output)
 
     # Ensure we only received hourly images with the proper billing code.
-    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
+    assert {"hourly" in x["name"] for x in parsed["images"]["aws"]}
     assert result.exit_code == 0
 
 
@@ -37,7 +36,7 @@ def test_aws_hourly_images_live(runner):
     parsed = json.loads(result.output)
 
     # Ensure we only received hourly images with the proper billing code.
-    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
+    assert {"hourly" in x["name"] for x in parsed["images"]["aws"]}
     assert result.exit_code == 0
 
 
@@ -47,7 +46,7 @@ def test_aws_hourly_images_offline(runner, mock_aws_regions, mock_aws_images):
     parsed = json.loads(result.output)
 
     # Ensure we only received hourly images with the proper billing code.
-    assert {x["UsageOperation"] for x in parsed} == {config.AWS_HOURLY_BILLING_CODE}
+    assert {"hourly" in x["name"] for x in parsed["images"]["aws"]}
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
This PR adds image formatting to the aws-hourly-images cli command to output a pre-formatted and validated image file.

part of: #106 

Non issue related fixes necessary for this PR:
- Needed to change schema.validate_json parameter type to arbitrary type of "object"
- Fixed name value in mocked AWS image list for Access image
##########################################################
EDIT:

Okay.. I've been dealing with Azure the entire morning and noticed what a mess it will be to replicate the same structure for Azure. We might need to integrate the image formatting methods into the cloud provider specific "get_image" calls to stay consistent..