### PR TITLE
Add Azure image formatting to CLI

### DIFF
--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -59,9 +59,9 @@ def gcp_images() -> None:
 
 @click.command()
 def azure_images() -> None:
-    """Dump Azure images from a region in JSON format."""
-    images = azure.get_images()
-    click.echo(json.dumps(images, indent=2))
+    """Dump Azure images in JSON format."""
+    images = azure.format_all_images()
+    dump_images(images)
 
 
 def dump_images(images: object) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,17 +95,16 @@ def test_azure_images_live(runner):
     result = runner.invoke(cli.azure_images)
     parsed = json.loads(result.output)
 
-    assert isinstance(parsed, list)
+    assert isinstance(parsed["images"]["azure"], list)
 
-    for image in parsed:
+    for image in parsed["images"]["azure"]:
         expected_keys = [
-            "architecture",
-            "hyperVGeneration",
-            "offer",
-            "publisher",
-            "sku",
-            "urn",
+            "name",
+            "arch",
             "version",
+            "imageId",
+            "date",
+            "virt",
         ]
         assert list(image.keys()) == expected_keys
 
@@ -119,17 +118,16 @@ def test_azure_images_offline(
     result = runner.invoke(cli.azure_images)
     parsed = json.loads(result.output)
 
-    assert isinstance(parsed, list)
+    assert isinstance(parsed["images"]["azure"], list)
 
-    for image in parsed:
+    for image in parsed["images"]["azure"]:
         expected_keys = [
-            "architecture",
-            "hyperVGeneration",
-            "offer",
-            "publisher",
-            "sku",
-            "urn",
+            "name",
+            "arch",
             "version",
+            "imageId",
+            "date",
+            "virt",
         ]
         assert list(image.keys()) == expected_keys
 


### PR DESCRIPTION
Changes: 
- Call format_all_images in azure_images CLI method. 
- Call dump_images in azure_images CLI method to ensure schema validation. 
- Adapt tests according to new schema approved format.

Part of #106 