### PR TITLE
Add REST API base implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ poetry add foo
 poetry add --group dev bar
 ```
 
+## Locator API server
+
+### Running the Flask server locally
+You can run the API server locally by using the rhelocator cli command `serve`:
+`poetry run rhelocator-updater serve --file-path <path to formatted image data>`
+
+By default, the swagger documenation is available at http://127.0.0.1:5000/apidocs/
+
+### Configuring the Flask server
+The API server will read its configuration on boot from the .env file located in
+`src/rhelocator/api/.env`.
+
+### Production build
+Still in progress. The current implementation only enables you to run the development server.
+A production build can be performed by using third party tools like
+[waitress](https://flask.palletsprojects.com/en/2.2.x/deploying/waitress/).
+
 ## Running tests
 
 Use poetry to run pytest:

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,6 +285,40 @@ pycodestyle = ">=2.9.0,<2.10.0"
 pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
+name = "flasgger"
+version = "0.9.5"
+description = "Extract swagger specs from your flask project"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = ">=0.10"
+jsonschema = ">=3.0.1"
+mistune = "*"
+PyYAML = ">=3.0"
+six = ">=1.10.0"
+
+[[package]]
+name = "flask"
+version = "2.2.2"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0"
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.2.2"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
@@ -424,7 +458,7 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "5.0.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -494,6 +528,14 @@ plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
+name = "itsdangerous"
+version = "2.1.2"
+description = "Safely pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "jedi"
 version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -507,6 +549,20 @@ parso = ">=0.8.0,<0.9.0"
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
+
+[[package]]
+name = "jinja2"
+version = "3.1.2"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jmespath"
@@ -541,6 +597,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "markupsafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.1.6"
 description = "Inline Matplotlib backend for Jupyter"
@@ -558,6 +622,14 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "mistune"
+version = "2.0.4"
+description = "A sane Markdown parser with useful plugins and renderers"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mypy"
@@ -984,10 +1056,21 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1211,6 +1294,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "werkzeug"
+version = "2.2.2"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog"]
+
+[[package]]
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -1230,7 +1327,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.10.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1241,7 +1338,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f41c5bfd80e76521e37fe0974019d302d1f5bc4ef727771ac34fcb190d43b659"
+content-hash = "b5b0123c0f2a71ba70d6b8fd7fa486ee53724fa6eb23255a0c332e7a3600ca25"
 
 [metadata.files]
 appnope = [
@@ -1407,6 +1504,14 @@ flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
+flasgger = [
+    {file = "flasgger-0.9.5-py2.py3-none-any.whl", hash = "sha256:0603941cf4003626b4ee551ca87331f1d17b8eecce500ccf1a1f1d3a332fc94a"},
+    {file = "flasgger-0.9.5.tar.gz", hash = "sha256:6ebea406b5beecd77e8da42550f380d4d05a6107bc90b69ce9e77aee7612e2d0"},
+]
+flask = [
+    {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
+    {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
+]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
@@ -1506,9 +1611,17 @@ isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
+itsdangerous = [
+    {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
+    {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
+]
 jedi = [
     {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
     {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+]
+jinja2 = [
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
 jmespath = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
@@ -1539,6 +1652,48 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.8.0-pp38-pypy38_pp73-any.whl", hash = "sha256:7e1561626c49cb394268edd00501b289053a652ed762c58e1081224c8d881cec"},
     {file = "lazy_object_proxy-1.8.0-pp39-pypy39_pp73-any.whl", hash = "sha256:ce58b2b3734c73e68f0e30e4e725264d4d6be95818ec0a0be4bb6bf9a7e79aa8"},
 ]
+markupsafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
 matplotlib-inline = [
     {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
     {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
@@ -1546,6 +1701,10 @@ matplotlib-inline = [
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mistune = [
+    {file = "mistune-2.0.4-py2.py3-none-any.whl", hash = "sha256:182cc5ee6f8ed1b807de6b7bb50155df7b66495412836b9a74c8fbdfc75fe36d"},
+    {file = "mistune-2.0.4.tar.gz", hash = "sha256:9ee0a66053e2267aba772c71e06891fa8f1af6d4b01d5e84e267b4570d4d9808"},
 ]
 mypy = [
     {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
@@ -1757,6 +1916,10 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+python-dotenv = [
+    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
+    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
+]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
@@ -1878,6 +2041,10 @@ virtualenv = [
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+werkzeug = [
+    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
+    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
 ]
 wrapt = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ requests = "^2.28.1"
 google-cloud-compute = "^1.6.0"
 click = "^8.1.3"
 jsonschema = "^4.16.0"
+flask = "^2.2.2"
+flasgger = "^0.9.5"
+python-dotenv = "^0.21.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"
@@ -87,6 +90,7 @@ enable_error_code = [
     "redundant-expr",
     "truthy-bool",
 ]
+disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
 addopts = "-n auto --cov=src/rhelocator --cov-report=term-missing --cov-report=xml --cov-branch"

--- a/src/rhelocator/api/config.py
+++ b/src/rhelocator/api/config.py
@@ -1,0 +1,7 @@
+from os import path
+
+from dotenv import load_dotenv
+
+
+basedir = path.abspath(path.dirname(__file__))
+load_dotenv(path.join(basedir, ".env"))

--- a/src/rhelocator/api/routes/gcp.py
+++ b/src/rhelocator/api/routes/gcp.py
@@ -1,0 +1,58 @@
+from typing import Optional
+
+from flasgger import swag_from
+from flask import Blueprint
+from flask import request
+
+
+def gcp_blueprint(data: list[dict[str, str]]) -> Blueprint:
+    """Creates and returns a Flask blueprint based that serves the provided
+    image data.
+
+    Args:
+        data: Formatted image data dict.
+
+    Returns:
+        Flask blueprint serving the provided data.
+    """
+    gcp_endpoint = Blueprint("api", __name__)
+
+    @gcp_endpoint.route("/gcp", methods=["GET"])
+    @swag_from("../schema/gcp.yml")
+    def endpoint() -> list[dict[str, str]]:
+        """Cloud Image Locator GCP Endpoint Provides RHEL image data for Google
+        Cloud."""
+
+        query: dict[str, str] = {}
+        name: Optional[str] = request.args.get("name")
+        arch: Optional[str] = request.args.get("arch")
+        image_id: Optional[str] = request.args.get("imageId")
+        date: Optional[str] = request.args.get("date")
+        version: Optional[str] = request.args.get("version")
+
+        if name:
+            query.update({"name": name})
+        if arch:
+            query.update({"arch": arch})
+        if image_id:
+            query.update({"imageId": image_id})
+        if date:
+            query.update({"date": date})
+        if version:
+            query.update({"version": version})
+
+        if len(query) == 0:
+            return data
+
+        response: list[dict[str, str]] = []
+        for image in data:
+            add_image = True
+            for key, value in query.items():
+                if value not in image[key]:
+                    add_image = False
+                    break
+            if add_image:
+                response.append(image)
+        return response
+
+    return gcp_endpoint

--- a/src/rhelocator/api/schema/gcp.yml
+++ b/src/rhelocator/api/schema/gcp.yml
@@ -1,0 +1,60 @@
+---
+parameters:
+  - name: name
+    in: query
+    type: string
+    example: RHEL 9 arm64
+  - name: date
+    in: query
+    type: string
+    example: 2022-11-02
+  - name: imageId
+    in: query
+    type: string
+    example: rhel-9-arm64-v20221102
+  - name: arch
+    in: query
+    type: string
+    example: x86_6
+  - name: version
+    in: query
+    type: string
+    example: 9
+
+definitions:
+  images:
+    type: array
+    items:
+      $ref: '#/definitions/image'
+  image:
+    type: object
+    properties:
+      arch:
+        type: string
+      date:
+        type: string
+      imageId:
+        type: string
+      name:
+        type: string
+      selflink:
+        type: string
+      version:
+        type: string
+
+responses:
+  200:
+    description: A list of Google Cloud Images
+    schema:
+      $ref: '#/definitions/images'
+    examples:
+      images: [
+          {
+            "arch":"x86_64",
+            "date":"2022-11-02T12:23:04.737-07:00",
+            "imageId":"rhel-7-v20221102",
+            "name":"RHEL 7 x86_64",
+            "selflink":"https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-7-v20221102",
+            "version":"7"
+          }
+        ]

--- a/src/rhelocator/api/server.py
+++ b/src/rhelocator/api/server.py
@@ -1,0 +1,51 @@
+import json
+
+from flasgger import Swagger
+from flask import Flask
+
+from rhelocator.api.routes.gcp import gcp_blueprint
+from rhelocator.update_images import schema
+
+
+def create_app(data_path: str) -> Flask:
+    """Creates and returns a Flask server configuration including cloud image
+    data.
+
+    Args:
+        data_path: String, path to image data JSON file.
+
+    Returns: A FLask instance
+    """
+    app = Flask(__name__)
+
+    app.config["SWAGGER"] = {
+        "title": "Cloud Image Locator",
+    }
+    Swagger(app)
+    # Add support for .env parsing:
+    app.config.from_pyfile("config.py")
+
+    with open(data_path) as f:
+        image_data = json.load(f)
+    schema.validate_json(image_data)
+
+    app.register_blueprint(
+        gcp_blueprint(image_data["images"]["google"]), url_prefix="/api"
+    )
+
+    return app
+
+
+def run(
+    host: str = "0.0.0.0", port: int = 5000, file_path: str = "./image-data.json"
+) -> None:
+    """Run a Flask server on the provided host address, port serving the image
+    data.
+
+    Args:
+        host: String, host address
+        port: Int, Port
+        file_path: String, path to image data JSON file
+    """
+    app = create_app(file_path)
+    app.run(host=host, port=port)

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -6,6 +6,7 @@ import json
 import click
 
 from rhelocator import __version__
+from rhelocator.api import server
 from rhelocator.update_images import aws
 from rhelocator.update_images import azure
 from rhelocator.update_images import gcp
@@ -70,7 +71,17 @@ def dump_images(images: object) -> None:
     click.echo(json.dumps(images, indent=2))
 
 
+@click.command()
+@click.option("--file-path", help="Path to JSON image data file.", type=str)
+@click.option("--port", help="Port to run Locator API at (optional).", type=int)
+@click.option("--host", help="Address to run Locator API at (optional).", type=str)
+def serve(file_path: str, port: int, host: str) -> None:
+    """Host API endpoint to serve cloud provider image data."""
+    server.run(file_path=file_path, port=port, host=host)
+
+
 cli.add_command(aws_hourly_images)
 cli.add_command(aws_regions)
 cli.add_command(azure_images)
 cli.add_command(gcp_images)
+cli.add_command(serve)

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -1,0 +1,66 @@
+"""Serve image data from public clouds."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rhelocator.api import server
+
+
+@pytest.fixture()
+def app():
+    app = server.create_app("tests/api/testdata/formatted_images.json")
+    app.config.update(
+        {
+            "TESTING": True,
+        }
+    )
+
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def runner(app):
+    return app.test_cli_runner()
+
+
+def test_request_gcp(client):
+    response = client.get("/api/gcp")
+    assert len(response.data) > 0
+    assert response.status_code == 200
+
+
+def test_request_gcp_with_query(client):
+    response = client.get(
+        "/api/gcp",
+        query_string={
+            "version": "9",
+        },
+    )
+    for image in json.loads(response.data):
+        assert image["version"] == "9"
+    assert response.status_code == 200
+
+
+def test_request_gcp_with_multi_query(client):
+    test_query = {
+        "name": "RHEL 9",
+        "arch": "arm64",
+        "version": "9",
+        "imageId": "rhel-9",
+        "date": "2022-11-02",
+    }
+    response = client.get("/api/gcp", query_string=test_query)
+    for image in json.loads(response.data):
+        assert test_query["name"] in image["name"]
+        assert test_query["arch"] in image["arch"]
+        assert test_query["version"] in image["version"]
+        assert test_query["imageId"] in image["imageId"]
+        assert test_query["date"] in image["date"]
+    assert response.status_code == 200

--- a/tests/api/testdata/formatted_images.json
+++ b/tests/api/testdata/formatted_images.json
@@ -1,0 +1,576 @@
+{
+  "images": {
+    "aws": [
+      {
+        "name": "RHEL 6.10 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "6.10",
+        "imageId": "ami-0f9f5ce4c5aeeff23",
+        "date": "2021-03-18T14:58:02.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0f9f5ce4c5aeeff23",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-09837a39e030a8e78",
+        "date": "2021-09-29T17:37:29.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-09837a39e030a8e78",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0d19256691ae1801c",
+        "date": "2021-02-09T09:59:51.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0d19256691ae1801c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0a443decce6d88dc2",
+        "date": "2021-05-18T19:26:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0a443decce6d88dc2",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-045c6839e9ba5c133",
+        "date": "2021-03-18T15:10:47.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-045c6839e9ba5c133",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.1.0",
+        "imageId": "ami-0855b46dffcfc750c",
+        "date": "2021-09-14T00:52:49.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0855b46dffcfc750c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.3.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3.0",
+        "imageId": "ami-0ff84575339cfb9cd",
+        "date": "2021-01-06T16:44:53.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ff84575339cfb9cd",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-0ef26d6024e6a182c",
+        "date": "2021-11-04T14:16:44.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ef26d6024e6a182c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-01edb389be6d2ae7f",
+        "date": "2022-10-27T21:26:20.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-01edb389be6d2ae7f",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-048c5d639c4cfa30a",
+        "date": "2022-11-03T17:01:16.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-048c5d639c4cfa30a",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.3 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.3",
+        "imageId": "ami-044b21dabdfb78334",
+        "date": "2021-02-10T15:39:04.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-044b21dabdfb78334",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-098c8e678e7ed196b",
+        "date": "2022-05-13T11:24:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-098c8e678e7ed196b",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.2.0",
+        "imageId": "ami-0bf64101b736c8498",
+        "date": "2021-10-07T14:09:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0bf64101b736c8498",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.2.0",
+        "imageId": "ami-08ab1a2f12968cf19",
+        "date": "2021-09-14T01:59:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-08ab1a2f12968cf19",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-0ccf13cffbdf2353a",
+        "date": "2021-11-02T15:09:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ccf13cffbdf2353a",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0751d8f53f850264a",
+        "date": "2021-09-02T00:34:13.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0751d8f53f850264a",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.4.0",
+        "imageId": "ami-0e69978a893eb61eb",
+        "date": "2021-09-02T00:50:42.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0e69978a893eb61eb",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.7.0",
+        "imageId": "ami-013f607d678d610d8",
+        "date": "2022-09-21T13:38:34.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-013f607d678d610d8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 6.10 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "6.10",
+        "imageId": "ami-0c22ca1423e1721e7",
+        "date": "2021-03-18T15:22:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0c22ca1423e1721e7",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0438539d8cb01d00b",
+        "date": "2021-03-18T15:41:22.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0438539d8cb01d00b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.6.0",
+        "imageId": "ami-0c64b6afe7613281a",
+        "date": "2022-05-05T11:06:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0c64b6afe7613281a",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-036468a96341b30d8",
+        "date": "2022-09-21T10:08:02.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-036468a96341b30d8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3",
+        "imageId": "ami-00f2ff91f93fb8c7c",
+        "date": "2021-02-10T16:41:58.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00f2ff91f93fb8c7c",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.5.0",
+        "imageId": "ami-014a71e6b7409bcf8",
+        "date": "2021-11-04T11:17:43.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-014a71e6b7409bcf8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-028ec75591896d688",
+        "date": "2021-11-02T15:48:46.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-028ec75591896d688",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0a6cbe57f527d241b",
+        "date": "2021-02-09T09:29:03.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0a6cbe57f527d241b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.7.0",
+        "imageId": "ami-00955a4c8096087c2",
+        "date": "2022-11-03T21:24:56.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00955a4c8096087c2",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.1.0",
+        "imageId": "ami-069b380b12f2294e2",
+        "date": "2021-10-07T14:29:32.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-069b380b12f2294e2",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.7.0",
+        "imageId": "ami-0cc08bd0e29a9af4b",
+        "date": "2022-11-03T20:28:22.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0cc08bd0e29a9af4b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-09e3391dca928f05f",
+        "date": "2022-05-13T11:29:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-09e3391dca928f05f",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0fe7507703898a688",
+        "date": "2022-10-27T20:22:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0fe7507703898a688",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-01ee92b22097ecf21",
+        "date": "2021-09-29T18:22:07.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-01ee92b22097ecf21",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.2.0",
+        "imageId": "ami-0a165ef9c45156397",
+        "date": "2021-09-13T23:49:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0a165ef9c45156397",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-0219fdf7ecff0a6ea",
+        "date": "2021-11-02T15:56:00.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0219fdf7ecff0a6ea",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0cf6249186288c4f0",
+        "date": "2021-05-18T18:26:10.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0cf6249186288c4f0",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5",
+        "imageId": "ami-0649621bce42a57c1",
+        "date": "2022-02-01T20:25:25.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0649621bce42a57c1",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.6.0",
+        "imageId": "ami-0f86a21d7d0c13d24",
+        "date": "2022-03-23T20:21:48.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0f86a21d7d0c13d24",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-0bcf2b8300d531545",
+        "date": "2022-05-13T11:34:56.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0bcf2b8300d531545",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.1.0",
+        "imageId": "ami-00e1f4212e87d82a6",
+        "date": "2021-09-13T22:30:59.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00e1f4212e87d82a6",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-064aeb2452a82205f",
+        "date": "2022-05-18T17:29:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-064aeb2452a82205f",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "9.1.0",
+        "imageId": "ami-0686ca4079daa3fb4",
+        "date": "2022-11-03T19:22:15.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0686ca4079daa3fb4",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-0ff8ecd3123adacce",
+        "date": "2021-11-04T11:52:11.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0ff8ecd3123adacce",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.5.0",
+        "imageId": "ami-027db7e09c94c0355",
+        "date": "2021-09-29T18:51:30.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-027db7e09c94c0355",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.7.0",
+        "imageId": "ami-07e9c60d679b6a8ac",
+        "date": "2022-09-21T14:40:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-07e9c60d679b6a8ac",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.6.0",
+        "imageId": "ami-062c4716a546acec9",
+        "date": "2022-05-05T10:13:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-062c4716a546acec9",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3.0",
+        "imageId": "ami-00cc788f028b75b53",
+        "date": "2021-01-06T16:59:48.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00cc788f028b75b53",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.3",
+        "imageId": "ami-05b566bbd37480a6e",
+        "date": "2021-02-10T16:37:16.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-05b566bbd37480a6e",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.1.0",
+        "imageId": "ami-031d52a783fbcb083",
+        "date": "2021-09-13T23:32:27.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-031d52a783fbcb083",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-03a53d58ec04750f8",
+        "date": "2022-11-03T17:19:11.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-03a53d58ec04750f8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.4.0",
+        "imageId": "ami-0fc559abb8e6eefdf",
+        "date": "2021-05-18T18:28:06.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0fc559abb8e6eefdf",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.5",
+        "imageId": "ami-07aa698107eb4c40b",
+        "date": "2022-02-01T22:20:31.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-07aa698107eb4c40b",
+        "region": "af-south-1"
+      }
+    ],
+    "azure": [
+      {
+        "name": "RHEL 7lvm-gen2 x64",
+        "arch": "x64",
+        "version": "7.9",
+        "imageId": "redhat:RHEL:7lvm-gen2:7.9.2022032206",
+        "date": "2022-03-22",
+        "virt": "V2"
+      },
+      {
+        "name": "RHEL 8-lvm-gen2 x64",
+        "arch": "x64",
+        "version": "8.6",
+        "imageId": "redhat:RHEL:8-lvm-gen2:8.6.2022102701",
+        "date": "2022-10-27",
+        "virt": "V2"
+      },
+      {
+        "name": "RHEL 9-lvm-gen2 x64",
+        "arch": "x64",
+        "version": "9.0",
+        "imageId": "redhat:RHEL:9-lvm-gen2:9.0.2022090601",
+        "date": "2022-09-06",
+        "virt": "V2"
+      }
+    ],
+    "google": [
+      {
+        "name": "RHEL 7 x86_64",
+        "arch": "x86_64",
+        "version": "7",
+        "imageId": "rhel-7-v20221102",
+        "date": "2022-11-02T12:23:04.737-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-7-v20221102"
+      },
+      {
+        "name": "RHEL 8 x86_64",
+        "arch": "x86_64",
+        "version": "8",
+        "imageId": "rhel-8-v20221102",
+        "date": "2022-11-02T12:23:04.790-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-8-v20221102"
+      },
+      {
+        "name": "RHEL 9 arm64",
+        "arch": "arm64",
+        "version": "9",
+        "imageId": "rhel-9-arm64-v20221102",
+        "date": "2022-11-02T12:23:04.925-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-9-arm64-v20221102"
+      },
+      {
+        "name": "RHEL 9 x86_64",
+        "arch": "x86_64",
+        "version": "9",
+        "imageId": "rhel-9-v20221102",
+        "date": "2022-11-02T12:23:04.705-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-9-v20221102"
+      }
+    ]
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,11 @@ def runner():
     return click.testing.CliRunner()
 
 
+@pytest.fixture
+def api_server(runner):
+    runner.invoke(cli.serve, ["--file-path=tests/api/testdata/formatted_images.json"])
+
+
 @pytest.mark.e2e
 def test_aws_hourly_images_live_opt_in_region(runner):
     """Run a live test against the AWS API to get hourly images for opt-in

--- a/tests/update_images/testdata/formatted_images.json
+++ b/tests/update_images/testdata/formatted_images.json
@@ -1,0 +1,576 @@
+{
+  "images": {
+    "aws": [
+      {
+        "name": "RHEL 6.10 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "6.10",
+        "imageId": "ami-0f9f5ce4c5aeeff23",
+        "date": "2021-03-18T14:58:02.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0f9f5ce4c5aeeff23",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-09837a39e030a8e78",
+        "date": "2021-09-29T17:37:29.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-09837a39e030a8e78",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0d19256691ae1801c",
+        "date": "2021-02-09T09:59:51.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0d19256691ae1801c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0a443decce6d88dc2",
+        "date": "2021-05-18T19:26:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0a443decce6d88dc2",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-045c6839e9ba5c133",
+        "date": "2021-03-18T15:10:47.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-045c6839e9ba5c133",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.1.0",
+        "imageId": "ami-0855b46dffcfc750c",
+        "date": "2021-09-14T00:52:49.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0855b46dffcfc750c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.3.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3.0",
+        "imageId": "ami-0ff84575339cfb9cd",
+        "date": "2021-01-06T16:44:53.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ff84575339cfb9cd",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-0ef26d6024e6a182c",
+        "date": "2021-11-04T14:16:44.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ef26d6024e6a182c",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-01edb389be6d2ae7f",
+        "date": "2022-10-27T21:26:20.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-01edb389be6d2ae7f",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-048c5d639c4cfa30a",
+        "date": "2022-11-03T17:01:16.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-048c5d639c4cfa30a",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.3 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.3",
+        "imageId": "ami-044b21dabdfb78334",
+        "date": "2021-02-10T15:39:04.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-044b21dabdfb78334",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-098c8e678e7ed196b",
+        "date": "2022-05-13T11:24:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-098c8e678e7ed196b",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.2.0",
+        "imageId": "ami-0bf64101b736c8498",
+        "date": "2021-10-07T14:09:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0bf64101b736c8498",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.2.0",
+        "imageId": "ami-08ab1a2f12968cf19",
+        "date": "2021-09-14T01:59:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-08ab1a2f12968cf19",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-0ccf13cffbdf2353a",
+        "date": "2021-11-02T15:09:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-0ccf13cffbdf2353a",
+        "region": "ap-southeast-2"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0751d8f53f850264a",
+        "date": "2021-09-02T00:34:13.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0751d8f53f850264a",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.4.0",
+        "imageId": "ami-0e69978a893eb61eb",
+        "date": "2021-09-02T00:50:42.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0e69978a893eb61eb",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.7.0",
+        "imageId": "ami-013f607d678d610d8",
+        "date": "2022-09-21T13:38:34.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-013f607d678d610d8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 6.10 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "6.10",
+        "imageId": "ami-0c22ca1423e1721e7",
+        "date": "2021-03-18T15:22:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0c22ca1423e1721e7",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0438539d8cb01d00b",
+        "date": "2021-03-18T15:41:22.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0438539d8cb01d00b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.6.0",
+        "imageId": "ami-0c64b6afe7613281a",
+        "date": "2022-05-05T11:06:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0c64b6afe7613281a",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-036468a96341b30d8",
+        "date": "2022-09-21T10:08:02.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-036468a96341b30d8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3",
+        "imageId": "ami-00f2ff91f93fb8c7c",
+        "date": "2021-02-10T16:41:58.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00f2ff91f93fb8c7c",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.5.0",
+        "imageId": "ami-014a71e6b7409bcf8",
+        "date": "2021-11-04T11:17:43.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-014a71e6b7409bcf8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-028ec75591896d688",
+        "date": "2021-11-02T15:48:46.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-028ec75591896d688",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0a6cbe57f527d241b",
+        "date": "2021-02-09T09:29:03.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0a6cbe57f527d241b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.7.0",
+        "imageId": "ami-00955a4c8096087c2",
+        "date": "2022-11-03T21:24:56.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00955a4c8096087c2",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.1.0",
+        "imageId": "ami-069b380b12f2294e2",
+        "date": "2021-10-07T14:29:32.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-069b380b12f2294e2",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.7.0",
+        "imageId": "ami-0cc08bd0e29a9af4b",
+        "date": "2022-11-03T20:28:22.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0cc08bd0e29a9af4b",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "9.0.0",
+        "imageId": "ami-09e3391dca928f05f",
+        "date": "2022-05-13T11:29:52.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-09e3391dca928f05f",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-0fe7507703898a688",
+        "date": "2022-10-27T20:22:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0fe7507703898a688",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-01ee92b22097ecf21",
+        "date": "2021-09-29T18:22:07.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-01ee92b22097ecf21",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.2.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.2.0",
+        "imageId": "ami-0a165ef9c45156397",
+        "date": "2021-09-13T23:49:40.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0a165ef9c45156397",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-0219fdf7ecff0a6ea",
+        "date": "2021-11-02T15:56:00.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0219fdf7ecff0a6ea",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.4.0",
+        "imageId": "ami-0cf6249186288c4f0",
+        "date": "2021-05-18T18:26:10.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0cf6249186288c4f0",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5",
+        "imageId": "ami-0649621bce42a57c1",
+        "date": "2022-02-01T20:25:25.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0649621bce42a57c1",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.6.0",
+        "imageId": "ami-0f86a21d7d0c13d24",
+        "date": "2022-03-23T20:21:48.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0f86a21d7d0c13d24",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.0.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.0.0",
+        "imageId": "ami-0bcf2b8300d531545",
+        "date": "2022-05-13T11:34:56.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0bcf2b8300d531545",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.1.0",
+        "imageId": "ami-00e1f4212e87d82a6",
+        "date": "2021-09-13T22:30:59.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00e1f4212e87d82a6",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 7.9 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "7.9",
+        "imageId": "ami-064aeb2452a82205f",
+        "date": "2022-05-18T17:29:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-064aeb2452a82205f",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "9.1.0",
+        "imageId": "ami-0686ca4079daa3fb4",
+        "date": "2022-11-03T19:22:15.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0686ca4079daa3fb4",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.5.0",
+        "imageId": "ami-0ff8ecd3123adacce",
+        "date": "2021-11-04T11:52:11.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0ff8ecd3123adacce",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5.0 hvm x86_64 Hourly2 BETA",
+        "arch": "x86_64",
+        "version": "8.5.0",
+        "imageId": "ami-027db7e09c94c0355",
+        "date": "2021-09-29T18:51:30.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-027db7e09c94c0355",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.7.0 hvm arm64 Hourly2 BETA",
+        "arch": "arm64",
+        "version": "8.7.0",
+        "imageId": "ami-07e9c60d679b6a8ac",
+        "date": "2022-09-21T14:40:08.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-07e9c60d679b6a8ac",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.6.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.6.0",
+        "imageId": "ami-062c4716a546acec9",
+        "date": "2022-05-05T10:13:21.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-062c4716a546acec9",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.3.0",
+        "imageId": "ami-00cc788f028b75b53",
+        "date": "2021-01-06T16:59:48.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-00cc788f028b75b53",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.3 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.3",
+        "imageId": "ami-05b566bbd37480a6e",
+        "date": "2021-02-10T16:37:16.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-05b566bbd37480a6e",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.1.0 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.1.0",
+        "imageId": "ami-031d52a783fbcb083",
+        "date": "2021-09-13T23:32:27.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-031d52a783fbcb083",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 9.1.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "9.1.0",
+        "imageId": "ami-03a53d58ec04750f8",
+        "date": "2022-11-03T17:19:11.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-03a53d58ec04750f8",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.4.0 hvm arm64 Hourly2 ",
+        "arch": "arm64",
+        "version": "8.4.0",
+        "imageId": "ami-0fc559abb8e6eefdf",
+        "date": "2021-05-18T18:28:06.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-0fc559abb8e6eefdf",
+        "region": "af-south-1"
+      },
+      {
+        "name": "RHEL 8.5 hvm x86_64 Hourly2 ",
+        "arch": "x86_64",
+        "version": "8.5",
+        "imageId": "ami-07aa698107eb4c40b",
+        "date": "2022-02-01T22:20:31.000Z",
+        "virt": "hvm",
+        "selflink": "https://console.aws.amazon.com/ec2/home?region=af-south-1#launchAmi=ami-07aa698107eb4c40b",
+        "region": "af-south-1"
+      }
+    ],
+    "azure": [
+      {
+        "name": "RHEL 7lvm-gen2 x64",
+        "arch": "x64",
+        "version": "7.9",
+        "imageId": "redhat:RHEL:7lvm-gen2:7.9.2022032206",
+        "date": "2022-03-22",
+        "virt": "V2"
+      },
+      {
+        "name": "RHEL 8-lvm-gen2 x64",
+        "arch": "x64",
+        "version": "8.6",
+        "imageId": "redhat:RHEL:8-lvm-gen2:8.6.2022102701",
+        "date": "2022-10-27",
+        "virt": "V2"
+      },
+      {
+        "name": "RHEL 9-lvm-gen2 x64",
+        "arch": "x64",
+        "version": "9.0",
+        "imageId": "redhat:RHEL:9-lvm-gen2:9.0.2022090601",
+        "date": "2022-09-06",
+        "virt": "V2"
+      }
+    ],
+    "google": [
+      {
+        "name": "RHEL 7 x86_64",
+        "arch": "x86_64",
+        "version": "7",
+        "imageId": "rhel-7-v20221102",
+        "date": "2022-11-02T12:23:04.737-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-7-v20221102"
+      },
+      {
+        "name": "RHEL 8 x86_64",
+        "arch": "x86_64",
+        "version": "8",
+        "imageId": "rhel-8-v20221102",
+        "date": "2022-11-02T12:23:04.790-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-8-v20221102"
+      },
+      {
+        "name": "RHEL 9 arm64",
+        "arch": "arm64",
+        "version": "9",
+        "imageId": "rhel-9-arm64-v20221102",
+        "date": "2022-11-02T12:23:04.925-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-9-arm64-v20221102"
+      },
+      {
+        "name": "RHEL 9 x86_64",
+        "arch": "x86_64",
+        "version": "9",
+        "imageId": "rhel-9-v20221102",
+        "date": "2022-11-02T12:23:04.705-07:00",
+        "selflink": "https://console.cloud.google.com/compute/imagesDetail/projects/rhel-cloud/global/images/rhel-9-v20221102"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds a new structure to the project:
src/rhelocator/api/
Hosts the REST API server creation logic and configuration environment.

..api/routes
Hosts the individual endpoints for GCP, (AWS, Azure not implemented yet)

..api/schema
Hosts the individual swagger schema definitions for GCP, (AWS, Azure not implemented yet)

What is missing?
- AWS / Azure
- production build of REST server
- running the REST server in the entrypoint of the locator container

How to run the server:
poetry run rhelocator-updater serve --file-path <path to formatted image data>

by default the server will start on 127.0.0.1:5000

API endpoints are reachable through 
127.0.0.1:5000/api/gcp

Swagger documentation is available 
http://127.0.0.1:5000/apidocs/

Notes: 
- had to deactivate mypy test of untyped decorators.

Solves #14 , #96 
Enables #47, #128, #129, #130, #131
