### PR TITLE
Add initial production environment to REST API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,27 @@ poetry add --group dev bar
 
 ### Running the Flask server locally
 You can run the API server locally by using the rhelocator cli command `serve`:
-`poetry run rhelocator-updater serve --file-path <path to formatted image data>`
+`poetry run rhelocator-updater serve --file-path <path to formatted image data> --dev`
 
-By default, the swagger documenation is available at http://127.0.0.1:5000/apidocs/
+```console
+Usage: rhelocator-updater serve [OPTIONS]
+
+  Host API endpoint to serve cloud provider image data.
+
+Options:
+  -f, --file-path TEXT  Path to JSON image data file.
+  -p, --port INTEGER    Port to run Locator API at.  [default: 5000]
+  -h, --host TEXT       Address to run Locator API at.  [default: 0.0.0.0]
+  -d, --dev             Run in development mode.
+  --help                Show this message and exit
+```
+
+While running the dev server, the swagger documenation will be available at
+http://127.0.0.1:5000/apidocs/ by default.
 
 ### Configuring the Flask server
 The API server will read its configuration on boot from the .env file located in
 `src/rhelocator/api/.env`.
-
-### Production build
-Still in progress. The current implementation only enables you to run the development server.
-A production build can be performed by using third party tools like
-[waitress](https://flask.palletsprojects.com/en/2.2.x/deploying/waitress/).
 
 ## Running tests
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1248,6 +1248,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-waitress"
+version = "2.1.4.3"
+description = "Typing stubs for waitress"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1284,6 +1292,18 @@ platformdirs = ">=2.4,<3"
 [package.extras]
 docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+
+[[package]]
+name = "waitress"
+version = "2.1.2"
+description = "Waitress WSGI server"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
 
 [[package]]
 name = "wcwidth"
@@ -1338,7 +1358,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "b5b0123c0f2a71ba70d6b8fd7fa486ee53724fa6eb23255a0c332e7a3600ca25"
+content-hash = "8af1e1bb7da6f1badc9c7e8bda89a4a94914d82a97d71cf797750de69f8c8b67"
 
 [metadata.files]
 appnope = [
@@ -2026,6 +2046,10 @@ types-urllib3 = [
     {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
     {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
 ]
+types-waitress = [
+    {file = "types-waitress-2.1.4.3.tar.gz", hash = "sha256:6c7d3a1a609b29365e8d410d44b7437b629b1ee0ec91bf9e8329cd3e7b0d1fbb"},
+    {file = "types_waitress-2.1.4.3-py3-none-any.whl", hash = "sha256:c5d9ad17613ec8757b504fce47daced71d7cc8199771aed56ff7891382e287f8"},
+]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
     {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
@@ -2037,6 +2061,10 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.16.7-py3-none-any.whl", hash = "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"},
     {file = "virtualenv-20.16.7.tar.gz", hash = "sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e"},
+]
+waitress = [
+    {file = "waitress-2.1.2-py3-none-any.whl", hash = "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a"},
+    {file = "waitress-2.1.2.tar.gz", hash = "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ jsonschema = "^4.16.0"
 flask = "^2.2.2"
 flasgger = "^0.9.5"
 python-dotenv = "^0.21.0"
+waitress = "^2.1.2"
+types-waitress = "^2.1.4.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/src/rhelocator/api/server.py
+++ b/src/rhelocator/api/server.py
@@ -7,7 +7,7 @@ from rhelocator.api.routes.gcp import gcp_blueprint
 from rhelocator.update_images import schema
 
 
-def create_app(data_path: str) -> Flask:
+def create_app(file_path: str) -> Flask:
     """Creates and returns a Flask server configuration including cloud image
     data.
 
@@ -25,7 +25,7 @@ def create_app(data_path: str) -> Flask:
     # Add support for .env parsing:
     app.config.from_pyfile("config.py")
 
-    with open(data_path) as f:
+    with open(file_path) as f:
         image_data = json.load(f)
     schema.validate_json(image_data)
 

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 
 import click
+import waitress
 
 from rhelocator import __version__
 from rhelocator.api import server
@@ -72,12 +73,33 @@ def dump_images(images: object) -> None:
 
 
 @click.command()
-@click.option("--file-path", help="Path to JSON image data file.", type=str)
-@click.option("--port", help="Port to run Locator API at (optional).", type=int)
-@click.option("--host", help="Address to run Locator API at (optional).", type=str)
-def serve(file_path: str, port: int, host: str) -> None:
+@click.option("-f", "--file-path", help="Path to JSON image data file.", type=str)
+@click.option(
+    "-p", "--port", show_default=True, default=5000, help="Port to run Locator API at."
+)
+@click.option(
+    "-h",
+    "--host",
+    show_default=True,
+    default="0.0.0.0",
+    help="Address to run Locator API at.",
+)
+@click.option(
+    "-d",
+    "--dev",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Run in development mode.",
+)
+def serve(file_path: str, port: int, host: str, dev: bool) -> None:
     """Host API endpoint to serve cloud provider image data."""
-    server.run(file_path=file_path, port=port, host=host)
+    if dev:
+        server.run(file_path=file_path, port=port, host=host)
+    else:
+        waitress.serve(
+            server.create_app(file_path=file_path), host=host, port=port, threads=4
+        )
 
 
 cli.add_command(aws_hourly_images)


### PR DESCRIPTION
This PR introduces waitress as WSGI server for hosting our Flask API endpoints.

Added
- --dev / -d flag to serve cli command to run Flask server in development mode
- waitress prod dependency 
- small fixes for staying consistent with property names (server.py file_path property)