### PR TITLE
Add api server to container

### DIFF
--- a/.github/workflows/container_release.yaml
+++ b/.github/workflows/container_release.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Merge JSON files
         run: |
-          jq -s 'reduce .[] as $item ({}; . * $item)' ./data/* >> image-data.json
+          jq -s 'reduce .[] as $item ({}; . * $item)' ./data/* >> ./data/image-data.json
           rm ./data/temp*.json
 
       - name: Build API container
@@ -107,5 +107,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Upload AWS hourly images
-          path: ./results
+          path: ./data
           retention-days: 7

--- a/.github/workflows/container_release.yaml
+++ b/.github/workflows/container_release.yaml
@@ -46,22 +46,18 @@ jobs:
         run: poetry install
 
       - name: Create output folder
-        run: mkdir -p results
+        run: mkdir -p data
 
       - name: List aws hourly images
         run: |
-          AWS_REGIONS=$(poetry run rhelocator-updater aws-regions)
-          regions=$(echo "$AWS_REGIONS" | jq -r '.[]')
-          for region in ${regions[@]}; do
-            poetry run rhelocator-updater aws-hourly-images --region $region >> ./results/aws_hourly_images.json
-          done
+          poetry run rhelocator-updater aws-hourly-images >> ./data/temp-aws-data.json
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: List azure images
         run: |
-          poetry run rhelocator-updater azure-images >> ./results/azure_images.json
+          poetry run rhelocator-updater azure-images >> ./data/temp-azure-data.json
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -76,9 +72,14 @@ jobs:
 
       - name: List Google Cloud images
         run: |
-          poetry run rhelocator-updater gcp-images >> ./results/gcp_images.json
+          poetry run rhelocator-updater gcp-images >> ./data/temp-gcp-data.json
         env:
           GOOGLE_APPLICATION_CREDENTIALS: '${{ steps.google_auth.outputs.credentials_file_path }}'
+
+      - name: Merge JSON files
+        run: |
+          jq -s 'reduce .[] as $item ({}; . * $item)' ./data/* >> image-data.json
+          rm ./data/temp*.json
 
       - name: Build API container
         id: build-image

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+data/
 develop-eggs/
 dist/
 downloads/

--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,4 @@ RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false
 RUN poetry install --only main --no-interaction --no-ansi
 
-# TODO: Implement API backend + add cli command to run and configure API
-# EXPOSE 8000
-# CMD ["poetry", "run", "rhelocator-cli", "serve", "--image-data", "/path/to/image/data.json"]
+CMD ["poetry", "run", "rhelocator-updater", "serve", "--file-path", "/opt/rhelocator/data/image-data.json"]

--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ The API server will read its configuration on boot from the .env file located in
 ```
 podman build -f Containerfile -t rhelocator:latest .
 ```
-or with podman:
-```
-podman build -f Containerfile -t rhelocator:latest .
-```
 
 2. Run the container, forward the Flask default port 5000 and mount a json file containing test data to
 `/opt/rhelocator/opt/rhelocator/data/image-data.json`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ http://127.0.0.1:5000/apidocs/ by default.
 The API server will read its configuration on boot from the .env file located in
 `src/rhelocator/api/.env`.
 
+### How to build the API container on your local system
+1. Build the container from within the rhelocator directory:
+```
+buildah bud -f ./Containerfile --format docker --tls-verify=true -t rhelocator:latest .
+```
+or with podman:
+```
+podman build -f Containerfile -t rhelocator:latest .
+```
+
+2. Run the container, forward the Flask default port 5000 and mount a json file containing test data to
+`/opt/rhelocator/opt/rhelocator/data/image-data.json`.
+```
+podman run -p 5000:5000  -v ./tests/api/testdata/formatted_images.json:/opt/rhelocator/data/image-data.json:Z rhelocator
+```
+Mind that this is only meant for local testing and should not run like this in production. The Z operator at the end of the
+volume mount is necessary for SELinux and applies the same (MCS)[https://en.wikipedia.org/wiki/Multi_categories_security]
+labels to the mounted data that the container will run with. For more information see this former (Project Atomic)[https://projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/] article (now CoreOS).
+
 ## Running tests
 
 Use poetry to run pytest:
@@ -133,3 +152,14 @@ Azure requires multiple environment variables:
 Google requires one environment variable that points to a JSON file or a block of JSON text.
 
 * `GOOGLE_APPLICATION_CREDENTIALS`: path to JSON credentials file or a block of JSON credentials text
+
+## Running the latest Cloud Image Locator backend
+1. Pull the newest locator image from quay:
+```
+podman pull quay.io/cloudexperience/cloud-image-locator:latest
+```
+
+2. Run the locator and forward the default port:
+```
+podman run -p 5000:5000 cloud-image-locator
+```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The API server will read its configuration on boot from the .env file located in
 ### How to build the API container on your local system
 1. Build the container from within the rhelocator directory:
 ```
-buildah bud -f ./Containerfile --format docker --tls-verify=true -t rhelocator:latest .
+podman build -f Containerfile -t rhelocator:latest .
 ```
 or with podman:
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -319,6 +319,18 @@ async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
 
 [[package]]
+name = "flask-cors"
+version = "3.0.10"
+description = "A Flask extension adding a decorator for CORS support"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = ">=0.9"
+Six = "*"
+
+[[package]]
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
@@ -1338,7 +1350,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "84fa330a995d9e38e86467c2ca87f52d03a8a19c20282d1d486c5ba7bc92f682"
+content-hash = "6698b562d1acd5fc85259869dd5a3e78d07c76b2a8d85525992aa29f19d151d0"
 
 [metadata.files]
 appnope = [
@@ -1511,6 +1523,10 @@ flasgger = [
 flask = [
     {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
     {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
+]
+flask-cors = [
+    {file = "Flask-Cors-3.0.10.tar.gz", hash = "sha256:b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de"},
+    {file = "Flask_Cors-3.0.10-py2.py3-none-any.whl", hash = "sha256:74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438"},
 ]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ flasgger = "^0.9.5"
 python-dotenv = "^0.21.0"
 waitress = "^2.1.2"
 types-waitress = "^2.1.4.3"
+flask-cors = "^3.0.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/src/rhelocator/api/server.py
+++ b/src/rhelocator/api/server.py
@@ -2,6 +2,7 @@ import json
 
 from flasgger import Swagger
 from flask import Flask
+from flask_cors import CORS
 
 from rhelocator.api.routes.aws import aws_blueprint
 from rhelocator.api.routes.azure import azure_blueprint
@@ -24,6 +25,9 @@ def create_app(file_path: str) -> Flask:
         "title": "Cloud Image Locator",
     }
     Swagger(app)
+
+    CORS(app)
+
     # Add support for .env parsing:
     app.config.from_pyfile("config.py")
 

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -21,28 +21,29 @@ def cli() -> None:
 
 
 @click.command()
-@click.option("--region", help="AWS region to query (optional)", type=str)
+@click.option(
+    "--region", help="Select specific AWS region to query (optional).", type=str
+)
 def aws_hourly_images(region: str) -> None:
-    """Dump AWS hourly images from a region in JSON format."""
-    # Verify that the user provided a region.
-    if not region:
-        raise click.UsageError(
-            "Provide a valid AWS region with --region, such as 'us-east-1'"
-        )
-    formatted_images: list[dict[str, str]] = []
+    """Dump AWS hourly images from a range of regions in JSON format.
 
-    # Is this a valid region?
-    valid_regions = aws.get_regions()
-    if region not in valid_regions:
-        message = f"{region} is not valid. Valid regions include: \n\n  "
-        message += "\n  ".join(valid_regions)
-        raise click.UsageError(message)
+    Returns images for all regions by default.
+    """
+    if region:
+        # Is this a valid region?
+        valid_regions = aws.get_regions()
+        if region not in valid_regions:
+            message = f"{region} is not valid. Valid regions include: \n\n  "
+            message += "\n  ".join(valid_regions)
+            raise click.UsageError(message)
 
-    images = aws.get_images(region)
-    for image in images:
-        formatted_images.append(aws.format_image(image, region))
-
-    dump_images({"images": {"aws": formatted_images}})
+        formatted_images: list[dict[str, str]] = []
+        images = aws.get_images(region)
+        for image in images:
+            formatted_images.append(aws.format_image(image, region))
+        dump_images({"images": {"aws": formatted_images}})
+    else:
+        dump_images({"images": {"aws": aws.format_all_images()}})
 
 
 @click.command()

--- a/src/rhelocator/cli.py
+++ b/src/rhelocator/cli.py
@@ -43,7 +43,7 @@ def aws_hourly_images(region: str) -> None:
             formatted_images.append(aws.format_image(image, region))
         dump_images({"images": {"aws": formatted_images}})
     else:
-        dump_images({"images": {"aws": aws.format_all_images()}})
+        dump_images(aws.format_all_images())
 
 
 @click.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,14 +55,6 @@ def test_aws_hourly_images_offline(runner, mock_aws_regions, mock_aws_images):
     assert result.exit_code == 0
 
 
-def test_aws_hourly_images_missing_region(runner):
-    """Simulate a failure to provide a region for the hourly images command."""
-    result = runner.invoke(cli.aws_hourly_images)
-
-    assert "Provide a valid AWS region" in result.output
-    assert result.exit_code == 2
-
-
 def test_aws_hourly_images_invalid_region(mock_aws_regions, runner):
     """Simulate a failure to provide a valid region for the hourly images
     command."""


### PR DESCRIPTION
- aws hourly cli command now outputs images for all regions by default. An individual region can still be supplied by using the --region flag.
- api endpoint execition is added to the container file
- small documentation on building and running the container locally

closes #131