### PR TITLE
Revert "[Update] cloud provider test data"

### DIFF
--- a/tests/update_images/testdata/aws_list_images.json
+++ b/tests/update_images/testdata/aws_list_images.json
@@ -1,1976 +1,1976 @@
 {
-    "Images": [
+  "Images": [
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-05-18T18:45:41.000Z",
+      "ImageId": "ami-02e0bb36c61bb9715",
+      "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
         {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-03T16:14:44.000Z",
-            "ImageId": "ami-0176fddd9698c4c3a",
-            "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-010781f8f49062c57",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T16:14:44.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-03T19:32:51.000Z",
-            "ImageId": "ami-0c08fd85d8f775888",
-            "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-02668108ddbc7146e",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T19:32:51.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-03T18:37:50.000Z",
-            "ImageId": "ami-08e637cea2f053dfa",
-            "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-03d1ef09b8d87947c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T18:37:50.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-02T00:07:57.000Z",
-            "ImageId": "ami-05723c3b9cf4bf4ff",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-00cf19e582ba8f17c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-02T00:07:56.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-11-02T15:33:24.000Z",
-            "ImageId": "ami-011598171b609aa36",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-02c94d9b8caa7d16c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-11-02T15:33:24.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-05-05T09:32:29.000Z",
-            "ImageId": "ami-06640050dc3f556bb",
-            "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0ebc25e8422901c8e",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-05-05T09:32:29.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-03-23T19:53:26.000Z",
-            "ImageId": "ami-073c570ae7a0977cb",
-            "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0f42712d5d7ceb2a4",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-03-23T19:53:26.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-02-10T16:09:34.000Z",
-            "ImageId": "ami-0846f86a5c7cb6d25",
-            "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a3e344c66212c494",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-02-10T16:09:34.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-02-01T22:03:37.000Z",
-            "ImageId": "ami-019599717e2dd5baa",
-            "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a3283a4c18f1873e",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-02-01T22:03:37.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-11-02T15:07:35.000Z",
-            "ImageId": "ami-0fb33ec3ead0b8e3f",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a7d67fe617f7fc7c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-11-02T15:07:35.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-01T20:07:41.000Z",
-            "ImageId": "ami-0d37ecbd75ec5a8c0",
-            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0c8cbffd2b7600c8e",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-01T20:07:41.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-02-09T09:46:19.000Z",
-            "ImageId": "ami-030e754805234517e",
-            "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-06558552e58534568",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-02-09T09:46:19.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-03-23T17:34:47.000Z",
-            "ImageId": "ami-05b640d310801a144",
-            "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0ad23efbfca7c1977",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-03-23T17:34:47.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-10-07T13:46:54.000Z",
-            "ImageId": "ami-0706d92706869e46f",
-            "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-00ba72d56dfca4804",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-10-07T13:46:54.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-02-22T19:11:17.000Z",
-            "ImageId": "ami-0051b1b2c5a166c8c",
-            "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0aad058902479a1c1",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-02-22T19:11:17.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-11-04T12:54:23.000Z",
-            "ImageId": "ami-06644055bed38ebd9",
-            "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-081fdba618fb27010",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-11-04T12:54:23.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2020-12-22T21:41:45.000Z",
-            "ImageId": "ami-0698b90665a2ddcf1",
-            "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-03c1cdd933e8e0388",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2022-12-22T21:41:45.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-11-03T19:46:03.000Z",
-            "ImageId": "ami-0a291b28b6d4b87fc",
-            "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0ace6060c23f7c01d",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T19:46:03.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-05-13T11:21:52.000Z",
-            "ImageId": "ami-0c41531b8d18cc72b",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-073f8b28002570466",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-05-13T11:21:52.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-10-27T20:59:23.000Z",
-            "ImageId": "ami-045393c081cabeb1f",
-            "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0e3bdf826c29ba8f3",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-10-27T20:59:23.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-05-18T18:45:41.000Z",
-            "ImageId": "ami-02e0bb36c61bb9715",
-            "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-09cef070be51e0d54",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-05-18T18:45:41.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-09-14T00:53:52.000Z",
-            "ImageId": "ami-03951dc3553ee499f",
-            "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0b6fba19dbdc3e202",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-14T00:53:52.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-03-22T23:07:45.000Z",
-            "ImageId": "ami-098453baf108a57d0",
-            "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0539db0c36394a20c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-03-22T23:07:45.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-10-11T15:52:18.000Z",
-            "ImageId": "ami-073955d8665a7a9e7",
-            "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-04dbc853e93a60050",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-10-11T15:52:18.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-09-01T22:42:25.000Z",
-            "ImageId": "ami-00c2075e4c33c96b1",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0772e3d6ab0e668f9",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-01T22:42:25.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-03-22T22:48:11.000Z",
-            "ImageId": "ami-03e95cf9553d62e4e",
-            "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-098e254b866bbbf84",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-03-22T22:48:11.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-03-18T14:30:58.000Z",
-            "ImageId": "ami-0a47672f6c7827dd2",
-            "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0d4a229075ac98ffe",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": false,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-03-18T14:30:58.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-02-01T22:35:37.000Z",
-            "ImageId": "ami-05a407c8573ef7269",
-            "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-074f0b737ea45a35b",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-02-01T22:35:37.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-09-29T16:34:35.000Z",
-            "ImageId": "ami-0fee3e66d33ee0f06",
-            "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0b1fa9ca91fbb0b68",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-29T16:34:35.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-05-18T20:09:47.000Z",
-            "ImageId": "ami-0b0af3577fe5e3532",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-03a3ad00558b4d17c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-05-18T20:09:47.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-10-27T22:12:53.000Z",
-            "ImageId": "ami-00e69c1911063647b",
-            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0cda51e2c43f39bb4",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-10-27T22:12:53.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-09-21T13:00:27.000Z",
-            "ImageId": "ami-09818359fcd692d8a",
-            "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-02c38351a829ac840",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-21T13:00:27.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-09-21T14:21:48.000Z",
-            "ImageId": "ami-04231e0f5229f26c7",
-            "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a06b8043e120c7a1",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-21T14:21:48.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-05-13T12:04:49.000Z",
-            "ImageId": "ami-08ddbe20d7e0d2f8f",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0af47e5c98135e3c4",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-05-13T12:04:49.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-09-29T17:02:36.000Z",
-            "ImageId": "ami-01bc2c0b484a594b6",
-            "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-02f6c8dde2ba5da81",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-29T17:02:36.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-09-13T23:15:20.000Z",
-            "ImageId": "ami-04d5b6962825b6f92",
-            "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-021290819a3011ff6",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-13T23:15:20.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-02-01T22:41:13.000Z",
-            "ImageId": "ami-0f095f89ae15be883",
-            "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-06e7cbd0bd9e9885b",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-02-01T22:41:13.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-11-03T19:23:02.000Z",
-            "ImageId": "ami-05c5c474dfb6af922",
-            "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-047275dadfd48c3b1",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T19:23:02.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-05-18T09:59:20.000Z",
-            "ImageId": "ami-004fac3d4533a2541",
-            "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-08ecb3a470135a7a6",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-05-18T09:59:20.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-11-04T11:39:13.000Z",
-            "ImageId": "ami-0dcff282af898b064",
-            "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-01a88a547081205b3",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-11-04T11:39:13.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-03-18T14:38:28.000Z",
-            "ImageId": "ami-069d22ec49577d4bf",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0537803fe544b6657",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-03-18T14:38:28.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-09-21T09:15:11.000Z",
-            "ImageId": "ami-0c82c5663e622b298",
-            "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0b1388bb0ec6eb24d",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-21T09:15:11.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-09-29T19:05:02.000Z",
-            "ImageId": "ami-07b828c02eecf97a0",
-            "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-055d424edd1ba54a3",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-29T19:05:02.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-10-27T19:17:26.000Z",
-            "ImageId": "ami-038df2ec824c24e80",
-            "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-087fe6e4f12f9012a",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-10-27T19:17:25.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-09-14T00:51:06.000Z",
-            "ImageId": "ami-02a393af854e372cc",
-            "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0473eebd0ff3d5c03",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-14T00:51:06.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-02-10T15:28:04.000Z",
-            "ImageId": "ami-01d12f05657cd01d3",
-            "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0ee2eb1654e98aa99",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-02-10T15:28:04.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-11-01T20:35:25.000Z",
-            "ImageId": "ami-050c88925ffb2bb50",
-            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-02159d201cbd2cdd2",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-01T20:35:25.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2021-05-18T19:06:34.000Z",
-            "ImageId": "ami-01fc429821bf1f4b4",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-00a2a295179f6d875",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-05-18T19:06:34.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-09-06T18:35:26.000Z",
-            "ImageId": "ami-0c93b29195d67a0ca",
-            "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-03283361ba297b0e6",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-06T18:35:26.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-10-07T13:43:25.000Z",
-            "ImageId": "ami-075ed2fafb0c1aa69",
-            "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-012b883849dd3774b",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-10-07T13:43:25.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-09-01T22:41:55.000Z",
-            "ImageId": "ami-03a454637e4aa453d",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a723d61baf388350",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-01T22:41:55.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-09-13T23:12:28.000Z",
-            "ImageId": "ami-07b1305cd78401892",
-            "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0d41a2d81432eacab",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-09-13T23:12:28.000Z"
-        },
-        {
-            "Architecture": "arm64",
-            "CreationDate": "2022-05-05T11:09:04.000Z",
-            "ImageId": "ami-0238411fb452f8275",
-            "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0221afb3433c26165",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-05-05T11:09:04.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-09-21T09:49:54.000Z",
-            "ImageId": "ami-0228302bab05078b4",
-            "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0a6951fc9c80e27d6",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-21T09:49:54.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-11-04T12:58:16.000Z",
-            "ImageId": "ami-0bd50e308e4cf942a",
-            "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-069584b5dccb6de20",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-11-04T12:58:16.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-11-03T18:01:07.000Z",
-            "ImageId": "ami-0bd7418456aaf76fb",
-            "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0652c860378b3fce5",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-11-03T18:01:07.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2021-03-18T14:23:11.000Z",
-            "ImageId": "ami-07eeb4db5f7e5a8fb",
-            "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux",
-            "UsageOperation": "RunInstances:0010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-05fff4469b5b3539c",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2023-03-18T14:23:11.000Z"
-        },
-        {
-            "Architecture": "x86_64",
-            "CreationDate": "2022-09-06T18:59:26.000Z",
-            "ImageId": "ami-06cc9ea389270405c",
-            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-            "ImageType": "machine",
-            "Public": true,
-            "OwnerId": "309956199498",
-            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-            "UsageOperation": "RunInstances:1010",
-            "State": "available",
-            "BlockDeviceMappings": [
-                {
-                    "DeviceName": "/dev/sda1",
-                    "Ebs": {
-                        "DeleteOnTermination": true,
-                        "SnapshotId": "snap-0d87d9a3b83b8e663",
-                        "VolumeSize": 10,
-                        "VolumeType": "gp2",
-                        "Encrypted": false
-                    }
-                }
-            ],
-            "Description": "Provided by Red Hat, Inc.",
-            "EnaSupport": true,
-            "Hypervisor": "xen",
-            "ImageOwnerAlias": "amazon",
-            "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-            "RootDeviceName": "/dev/sda1",
-            "RootDeviceType": "ebs",
-            "SriovNetSupport": "simple",
-            "VirtualizationType": "hvm",
-            "DeprecationTime": "2024-09-06T18:59:26.000Z"
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-09cef070be51e0d54",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-    ]
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T18:45:41.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-05-05T11:09:04.000Z",
+      "ImageId": "ami-0238411fb452f8275",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0221afb3433c26165",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-05T11:09:04.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-09-21T09:15:11.000Z",
+      "ImageId": "ami-0c82c5663e622b298",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b1388bb0ec6eb24d",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T09:15:11.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T19:32:51.000Z",
+      "ImageId": "ami-0c08fd85d8f775888",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02668108ddbc7146e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:32:51.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-05-18T20:09:47.000Z",
+      "ImageId": "ami-0b0af3577fe5e3532",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03a3ad00558b4d17c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T20:09:47.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-22T23:07:45.000Z",
+      "ImageId": "ami-098453baf108a57d0",
+      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0539db0c36394a20c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-22T23:07:45.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-27T22:12:53.000Z",
+      "ImageId": "ami-00e69c1911063647b",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0cda51e2c43f39bb4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-27T22:12:53.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-09-21T14:21:48.000Z",
+      "ImageId": "ami-04231e0f5229f26c7",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a06b8043e120c7a1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T14:21:48.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-21T09:49:54.000Z",
+      "ImageId": "ami-0228302bab05078b4",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a6951fc9c80e27d6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T09:49:54.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-22T19:11:17.000Z",
+      "ImageId": "ami-0051b1b2c5a166c8c",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0aad058902479a1c1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-22T19:11:17.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-01T22:41:55.000Z",
+      "ImageId": "ami-03a454637e4aa453d",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a723d61baf388350",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-01T22:41:55.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-05-18T19:06:34.000Z",
+      "ImageId": "ami-01fc429821bf1f4b4",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00a2a295179f6d875",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T19:06:34.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-10-27T20:59:23.000Z",
+      "ImageId": "ami-045393c081cabeb1f",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0e3bdf826c29ba8f3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-10-27T20:59:23.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-04T12:54:23.000Z",
+      "ImageId": "ami-06644055bed38ebd9",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-081fdba618fb27010",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T12:54:23.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T18:37:50.000Z",
+      "ImageId": "ami-08e637cea2f053dfa",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03d1ef09b8d87947c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T18:37:50.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-02-10T16:09:34.000Z",
+      "ImageId": "ami-0846f86a5c7cb6d25",
+      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a3e344c66212c494",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-10T16:09:34.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-01T22:42:25.000Z",
+      "ImageId": "ami-00c2075e4c33c96b1",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0772e3d6ab0e668f9",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-01T22:42:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-03-23T19:53:26.000Z",
+      "ImageId": "ami-073c570ae7a0977cb",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0f42712d5d7ceb2a4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-03-23T19:53:26.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-18T14:30:58.000Z",
+      "ImageId": "ami-0a47672f6c7827dd2",
+      "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d4a229075ac98ffe",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": false,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:30:58.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-01T20:35:25.000Z",
+      "ImageId": "ami-050c88925ffb2bb50",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02159d201cbd2cdd2",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-01T20:35:25.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-03-23T17:34:47.000Z",
+      "ImageId": "ami-05b640d310801a144",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ad23efbfca7c1977",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-03-23T17:34:47.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-14T00:51:06.000Z",
+      "ImageId": "ami-02a393af854e372cc",
+      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0473eebd0ff3d5c03",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-14T00:51:06.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-06T18:59:26.000Z",
+      "ImageId": "ami-06cc9ea389270405c",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d87d9a3b83b8e663",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-06T18:59:26.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-29T19:05:02.000Z",
+      "ImageId": "ami-07b828c02eecf97a0",
+      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-055d424edd1ba54a3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T19:05:02.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-02-01T22:35:37.000Z",
+      "ImageId": "ami-05a407c8573ef7269",
+      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-074f0b737ea45a35b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:35:37.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-02T00:07:57.000Z",
+      "ImageId": "ami-05723c3b9cf4bf4ff",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00cf19e582ba8f17c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-02T00:07:56.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-05T09:32:29.000Z",
+      "ImageId": "ami-06640050dc3f556bb",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ebc25e8422901c8e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-05T09:32:29.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-07T13:43:25.000Z",
+      "ImageId": "ami-075ed2fafb0c1aa69",
+      "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-012b883849dd3774b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-07T13:43:25.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-03-18T14:38:28.000Z",
+      "ImageId": "ami-069d22ec49577d4bf",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0537803fe544b6657",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:38:28.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-21T13:00:27.000Z",
+      "ImageId": "ami-09818359fcd692d8a",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02c38351a829ac840",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T13:00:27.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-18T09:59:20.000Z",
+      "ImageId": "ami-004fac3d4533a2541",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-08ecb3a470135a7a6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-18T09:59:20.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-13T11:21:52.000Z",
+      "ImageId": "ami-0c41531b8d18cc72b",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-073f8b28002570466",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-13T11:21:52.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-07T13:46:54.000Z",
+      "ImageId": "ami-0706d92706869e46f",
+      "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00ba72d56dfca4804",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-07T13:46:54.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-02-10T15:28:04.000Z",
+      "ImageId": "ami-01d12f05657cd01d3",
+      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ee2eb1654e98aa99",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-10T15:28:04.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-02-09T09:46:19.000Z",
+      "ImageId": "ami-030e754805234517e",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-06558552e58534568",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-09T09:46:19.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-01T20:07:41.000Z",
+      "ImageId": "ami-0d37ecbd75ec5a8c0",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0c8cbffd2b7600c8e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-01T20:07:41.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-04T12:58:16.000Z",
+      "ImageId": "ami-0bd50e308e4cf942a",
+      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-069584b5dccb6de20",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T12:58:16.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-01T22:03:37.000Z",
+      "ImageId": "ami-019599717e2dd5baa",
+      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a3283a4c18f1873e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:03:37.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-29T16:34:35.000Z",
+      "ImageId": "ami-0fee3e66d33ee0f06",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b1fa9ca91fbb0b68",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T16:34:35.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-29T17:02:36.000Z",
+      "ImageId": "ami-01bc2c0b484a594b6",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02f6c8dde2ba5da81",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T17:02:36.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-13T23:12:28.000Z",
+      "ImageId": "ami-07b1305cd78401892",
+      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d41a2d81432eacab",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-13T23:12:28.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T16:14:44.000Z",
+      "ImageId": "ami-0176fddd9698c4c3a",
+      "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-010781f8f49062c57",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T16:14:44.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-06T18:35:26.000Z",
+      "ImageId": "ami-0c93b29195d67a0ca",
+      "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03283361ba297b0e6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-06T18:35:26.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-02T15:07:35.000Z",
+      "ImageId": "ami-0fb33ec3ead0b8e3f",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a7d67fe617f7fc7c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-02T15:07:35.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-18T14:23:11.000Z",
+      "ImageId": "ami-07eeb4db5f7e5a8fb",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-05fff4469b5b3539c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:23:11.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-10-27T19:17:26.000Z",
+      "ImageId": "ami-038df2ec824c24e80",
+      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-087fe6e4f12f9012a",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-10-27T19:17:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-22T22:48:11.000Z",
+      "ImageId": "ami-03e95cf9553d62e4e",
+      "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-098e254b866bbbf84",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-22T22:48:11.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-05-13T12:04:49.000Z",
+      "ImageId": "ami-08ddbe20d7e0d2f8f",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0af47e5c98135e3c4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-13T12:04:49.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-03T19:23:02.000Z",
+      "ImageId": "ami-05c5c474dfb6af922",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-047275dadfd48c3b1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:23:02.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-11-04T11:39:13.000Z",
+      "ImageId": "ami-0dcff282af898b064",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-01a88a547081205b3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T11:39:13.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T18:01:07.000Z",
+      "ImageId": "ami-0bd7418456aaf76fb",
+      "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0652c860378b3fce5",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T18:01:07.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-11T15:52:18.000Z",
+      "ImageId": "ami-073955d8665a7a9e7",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-04dbc853e93a60050",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-11T15:52:18.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-11-02T15:33:24.000Z",
+      "ImageId": "ami-011598171b609aa36",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02c94d9b8caa7d16c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-02T15:33:24.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2020-12-22T21:41:45.000Z",
+      "ImageId": "ami-0698b90665a2ddcf1",
+      "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03c1cdd933e8e0388",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2022-12-22T21:41:45.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-03T19:46:03.000Z",
+      "ImageId": "ami-0a291b28b6d4b87fc",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ace6060c23f7c01d",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:46:03.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-13T23:15:20.000Z",
+      "ImageId": "ami-04d5b6962825b6f92",
+      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-021290819a3011ff6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-13T23:15:20.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-01T22:41:13.000Z",
+      "ImageId": "ami-0f095f89ae15be883",
+      "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-06e7cbd0bd9e9885b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:41:13.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-14T00:53:52.000Z",
+      "ImageId": "ami-03951dc3553ee499f",
+      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b6fba19dbdc3e202",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
+        }
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-14T00:53:52.000Z"
+    }
+  ]
 }

--- a/tests/update_images/testdata/aws_list_images.json
+++ b/tests/update_images/testdata/aws_list_images.json
@@ -1,1976 +1,1976 @@
 {
-  "Images": [
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-03T16:14:44.000Z",
-      "ImageId": "ami-0176fddd9698c4c3a",
-      "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+    "Images": [
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-010781f8f49062c57",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T16:14:44.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-03T19:32:51.000Z",
-      "ImageId": "ami-0c08fd85d8f775888",
-      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-03T16:14:44.000Z",
+            "ImageId": "ami-0176fddd9698c4c3a",
+            "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-010781f8f49062c57",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T16:14:44.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-02668108ddbc7146e",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T19:32:51.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-03T18:37:50.000Z",
-      "ImageId": "ami-08e637cea2f053dfa",
-      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-03T19:32:51.000Z",
+            "ImageId": "ami-0c08fd85d8f775888",
+            "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-02668108ddbc7146e",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T19:32:51.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-03d1ef09b8d87947c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T18:37:50.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-02T00:07:57.000Z",
-      "ImageId": "ami-05723c3b9cf4bf4ff",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-03T18:37:50.000Z",
+            "ImageId": "ami-08e637cea2f053dfa",
+            "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-03d1ef09b8d87947c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T18:37:50.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-00cf19e582ba8f17c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-02T00:07:56.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-11-02T15:33:24.000Z",
-      "ImageId": "ami-011598171b609aa36",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-02T00:07:57.000Z",
+            "ImageId": "ami-05723c3b9cf4bf4ff",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-00cf19e582ba8f17c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-02T00:07:56.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-02c94d9b8caa7d16c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-11-02T15:33:24.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-05-05T09:32:29.000Z",
-      "ImageId": "ami-06640050dc3f556bb",
-      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-11-02T15:33:24.000Z",
+            "ImageId": "ami-011598171b609aa36",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-02c94d9b8caa7d16c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-11-02T15:33:24.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0ebc25e8422901c8e",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-05-05T09:32:29.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-03-23T19:53:26.000Z",
-      "ImageId": "ami-073c570ae7a0977cb",
-      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-05-05T09:32:29.000Z",
+            "ImageId": "ami-06640050dc3f556bb",
+            "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0ebc25e8422901c8e",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-05-05T09:32:29.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0f42712d5d7ceb2a4",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-03-23T19:53:26.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-02-10T16:09:34.000Z",
-      "ImageId": "ami-0846f86a5c7cb6d25",
-      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-03-23T19:53:26.000Z",
+            "ImageId": "ami-073c570ae7a0977cb",
+            "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0f42712d5d7ceb2a4",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-03-23T19:53:26.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a3e344c66212c494",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-02-10T16:09:34.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-02-01T22:03:37.000Z",
-      "ImageId": "ami-019599717e2dd5baa",
-      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-02-10T16:09:34.000Z",
+            "ImageId": "ami-0846f86a5c7cb6d25",
+            "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a3e344c66212c494",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-02-10T16:09:34.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a3283a4c18f1873e",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-02-01T22:03:37.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-11-02T15:07:35.000Z",
-      "ImageId": "ami-0fb33ec3ead0b8e3f",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-02-01T22:03:37.000Z",
+            "ImageId": "ami-019599717e2dd5baa",
+            "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a3283a4c18f1873e",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-02-01T22:03:37.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a7d67fe617f7fc7c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-11-02T15:07:35.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-01T20:07:41.000Z",
-      "ImageId": "ami-0d37ecbd75ec5a8c0",
-      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-11-02T15:07:35.000Z",
+            "ImageId": "ami-0fb33ec3ead0b8e3f",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a7d67fe617f7fc7c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-11-02T15:07:35.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0c8cbffd2b7600c8e",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-01T20:07:41.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-02-09T09:46:19.000Z",
-      "ImageId": "ami-030e754805234517e",
-      "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-01T20:07:41.000Z",
+            "ImageId": "ami-0d37ecbd75ec5a8c0",
+            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0c8cbffd2b7600c8e",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-01T20:07:41.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-06558552e58534568",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-02-09T09:46:19.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-03-23T17:34:47.000Z",
-      "ImageId": "ami-05b640d310801a144",
-      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-02-09T09:46:19.000Z",
+            "ImageId": "ami-030e754805234517e",
+            "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-06558552e58534568",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-02-09T09:46:19.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0ad23efbfca7c1977",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-03-23T17:34:47.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-10-07T13:46:54.000Z",
-      "ImageId": "ami-0706d92706869e46f",
-      "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-03-23T17:34:47.000Z",
+            "ImageId": "ami-05b640d310801a144",
+            "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0ad23efbfca7c1977",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-03-23T17:34:47.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-00ba72d56dfca4804",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-10-07T13:46:54.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-02-22T19:11:17.000Z",
-      "ImageId": "ami-0051b1b2c5a166c8c",
-      "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-10-07T13:46:54.000Z",
+            "ImageId": "ami-0706d92706869e46f",
+            "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-00ba72d56dfca4804",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-10-07T13:46:54.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0aad058902479a1c1",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-02-22T19:11:17.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-11-04T12:54:23.000Z",
-      "ImageId": "ami-06644055bed38ebd9",
-      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-02-22T19:11:17.000Z",
+            "ImageId": "ami-0051b1b2c5a166c8c",
+            "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0aad058902479a1c1",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-02-22T19:11:17.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-081fdba618fb27010",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-11-04T12:54:23.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2020-12-22T21:41:45.000Z",
-      "ImageId": "ami-0698b90665a2ddcf1",
-      "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-11-04T12:54:23.000Z",
+            "ImageId": "ami-06644055bed38ebd9",
+            "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-081fdba618fb27010",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-11-04T12:54:23.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-03c1cdd933e8e0388",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2022-12-22T21:41:45.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-11-03T19:46:03.000Z",
-      "ImageId": "ami-0a291b28b6d4b87fc",
-      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2020-12-22T21:41:45.000Z",
+            "ImageId": "ami-0698b90665a2ddcf1",
+            "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-03c1cdd933e8e0388",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2022-12-22T21:41:45.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0ace6060c23f7c01d",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T19:46:03.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-05-13T11:21:52.000Z",
-      "ImageId": "ami-0c41531b8d18cc72b",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-11-03T19:46:03.000Z",
+            "ImageId": "ami-0a291b28b6d4b87fc",
+            "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0ace6060c23f7c01d",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T19:46:03.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-073f8b28002570466",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-05-13T11:21:52.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-10-27T20:59:23.000Z",
-      "ImageId": "ami-045393c081cabeb1f",
-      "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-05-13T11:21:52.000Z",
+            "ImageId": "ami-0c41531b8d18cc72b",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-073f8b28002570466",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-05-13T11:21:52.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0e3bdf826c29ba8f3",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-10-27T20:59:23.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-05-18T18:45:41.000Z",
-      "ImageId": "ami-02e0bb36c61bb9715",
-      "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-10-27T20:59:23.000Z",
+            "ImageId": "ami-045393c081cabeb1f",
+            "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0e3bdf826c29ba8f3",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-10-27T20:59:23.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-09cef070be51e0d54",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-05-18T18:45:41.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-09-14T00:53:52.000Z",
-      "ImageId": "ami-03951dc3553ee499f",
-      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-05-18T18:45:41.000Z",
+            "ImageId": "ami-02e0bb36c61bb9715",
+            "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-09cef070be51e0d54",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-05-18T18:45:41.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0b6fba19dbdc3e202",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-14T00:53:52.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-03-22T23:07:45.000Z",
-      "ImageId": "ami-098453baf108a57d0",
-      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-09-14T00:53:52.000Z",
+            "ImageId": "ami-03951dc3553ee499f",
+            "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0b6fba19dbdc3e202",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-14T00:53:52.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0539db0c36394a20c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-03-22T23:07:45.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-10-11T15:52:18.000Z",
-      "ImageId": "ami-073955d8665a7a9e7",
-      "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-03-22T23:07:45.000Z",
+            "ImageId": "ami-098453baf108a57d0",
+            "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0539db0c36394a20c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-03-22T23:07:45.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-04dbc853e93a60050",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-10-11T15:52:18.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-09-01T22:42:25.000Z",
-      "ImageId": "ami-00c2075e4c33c96b1",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-10-11T15:52:18.000Z",
+            "ImageId": "ami-073955d8665a7a9e7",
+            "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-04dbc853e93a60050",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-10-11T15:52:18.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0772e3d6ab0e668f9",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-01T22:42:25.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-03-22T22:48:11.000Z",
-      "ImageId": "ami-03e95cf9553d62e4e",
-      "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-09-01T22:42:25.000Z",
+            "ImageId": "ami-00c2075e4c33c96b1",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0772e3d6ab0e668f9",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-01T22:42:25.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-098e254b866bbbf84",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-03-22T22:48:11.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-03-18T14:30:58.000Z",
-      "ImageId": "ami-0a47672f6c7827dd2",
-      "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-03-22T22:48:11.000Z",
+            "ImageId": "ami-03e95cf9553d62e4e",
+            "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-098e254b866bbbf84",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-03-22T22:48:11.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0d4a229075ac98ffe",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": false,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-03-18T14:30:58.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-02-01T22:35:37.000Z",
-      "ImageId": "ami-05a407c8573ef7269",
-      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-03-18T14:30:58.000Z",
+            "ImageId": "ami-0a47672f6c7827dd2",
+            "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0d4a229075ac98ffe",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": false,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-03-18T14:30:58.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-074f0b737ea45a35b",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-02-01T22:35:37.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-09-29T16:34:35.000Z",
-      "ImageId": "ami-0fee3e66d33ee0f06",
-      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-02-01T22:35:37.000Z",
+            "ImageId": "ami-05a407c8573ef7269",
+            "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-074f0b737ea45a35b",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-02-01T22:35:37.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0b1fa9ca91fbb0b68",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-29T16:34:35.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-05-18T20:09:47.000Z",
-      "ImageId": "ami-0b0af3577fe5e3532",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-09-29T16:34:35.000Z",
+            "ImageId": "ami-0fee3e66d33ee0f06",
+            "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0b1fa9ca91fbb0b68",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-29T16:34:35.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-03a3ad00558b4d17c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-05-18T20:09:47.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-10-27T22:12:53.000Z",
-      "ImageId": "ami-00e69c1911063647b",
-      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-05-18T20:09:47.000Z",
+            "ImageId": "ami-0b0af3577fe5e3532",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-03a3ad00558b4d17c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-05-18T20:09:47.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0cda51e2c43f39bb4",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-10-27T22:12:53.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-09-21T13:00:27.000Z",
-      "ImageId": "ami-09818359fcd692d8a",
-      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-10-27T22:12:53.000Z",
+            "ImageId": "ami-00e69c1911063647b",
+            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0cda51e2c43f39bb4",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-10-27T22:12:53.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-02c38351a829ac840",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-21T13:00:27.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-09-21T14:21:48.000Z",
-      "ImageId": "ami-04231e0f5229f26c7",
-      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-09-21T13:00:27.000Z",
+            "ImageId": "ami-09818359fcd692d8a",
+            "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-02c38351a829ac840",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-21T13:00:27.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a06b8043e120c7a1",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-21T14:21:48.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-05-13T12:04:49.000Z",
-      "ImageId": "ami-08ddbe20d7e0d2f8f",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-09-21T14:21:48.000Z",
+            "ImageId": "ami-04231e0f5229f26c7",
+            "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a06b8043e120c7a1",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-21T14:21:48.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0af47e5c98135e3c4",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-05-13T12:04:49.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-09-29T17:02:36.000Z",
-      "ImageId": "ami-01bc2c0b484a594b6",
-      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-05-13T12:04:49.000Z",
+            "ImageId": "ami-08ddbe20d7e0d2f8f",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0af47e5c98135e3c4",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-05-13T12:04:49.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-02f6c8dde2ba5da81",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-29T17:02:36.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-09-13T23:15:20.000Z",
-      "ImageId": "ami-04d5b6962825b6f92",
-      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-09-29T17:02:36.000Z",
+            "ImageId": "ami-01bc2c0b484a594b6",
+            "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-02f6c8dde2ba5da81",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-29T17:02:36.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-021290819a3011ff6",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-13T23:15:20.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-02-01T22:41:13.000Z",
-      "ImageId": "ami-0f095f89ae15be883",
-      "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-09-13T23:15:20.000Z",
+            "ImageId": "ami-04d5b6962825b6f92",
+            "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-021290819a3011ff6",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-13T23:15:20.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-06e7cbd0bd9e9885b",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-02-01T22:41:13.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-11-03T19:23:02.000Z",
-      "ImageId": "ami-05c5c474dfb6af922",
-      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-02-01T22:41:13.000Z",
+            "ImageId": "ami-0f095f89ae15be883",
+            "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-06e7cbd0bd9e9885b",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-02-01T22:41:13.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-047275dadfd48c3b1",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T19:23:02.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-05-18T09:59:20.000Z",
-      "ImageId": "ami-004fac3d4533a2541",
-      "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-11-03T19:23:02.000Z",
+            "ImageId": "ami-05c5c474dfb6af922",
+            "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-047275dadfd48c3b1",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T19:23:02.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-08ecb3a470135a7a6",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-05-18T09:59:20.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-11-04T11:39:13.000Z",
-      "ImageId": "ami-0dcff282af898b064",
-      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-05-18T09:59:20.000Z",
+            "ImageId": "ami-004fac3d4533a2541",
+            "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-08ecb3a470135a7a6",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-05-18T09:59:20.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-01a88a547081205b3",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-11-04T11:39:13.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-03-18T14:38:28.000Z",
-      "ImageId": "ami-069d22ec49577d4bf",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-11-04T11:39:13.000Z",
+            "ImageId": "ami-0dcff282af898b064",
+            "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-01a88a547081205b3",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-11-04T11:39:13.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0537803fe544b6657",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-03-18T14:38:28.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-09-21T09:15:11.000Z",
-      "ImageId": "ami-0c82c5663e622b298",
-      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-03-18T14:38:28.000Z",
+            "ImageId": "ami-069d22ec49577d4bf",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0537803fe544b6657",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-03-18T14:38:28.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0b1388bb0ec6eb24d",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-21T09:15:11.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-09-29T19:05:02.000Z",
-      "ImageId": "ami-07b828c02eecf97a0",
-      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-09-21T09:15:11.000Z",
+            "ImageId": "ami-0c82c5663e622b298",
+            "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0b1388bb0ec6eb24d",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-21T09:15:11.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-055d424edd1ba54a3",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-29T19:05:02.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-10-27T19:17:26.000Z",
-      "ImageId": "ami-038df2ec824c24e80",
-      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-09-29T19:05:02.000Z",
+            "ImageId": "ami-07b828c02eecf97a0",
+            "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-055d424edd1ba54a3",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-29T19:05:02.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-087fe6e4f12f9012a",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-10-27T19:17:25.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-09-14T00:51:06.000Z",
-      "ImageId": "ami-02a393af854e372cc",
-      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-10-27T19:17:26.000Z",
+            "ImageId": "ami-038df2ec824c24e80",
+            "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-087fe6e4f12f9012a",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-10-27T19:17:25.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0473eebd0ff3d5c03",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-14T00:51:06.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-02-10T15:28:04.000Z",
-      "ImageId": "ami-01d12f05657cd01d3",
-      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-09-14T00:51:06.000Z",
+            "ImageId": "ami-02a393af854e372cc",
+            "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0473eebd0ff3d5c03",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-14T00:51:06.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0ee2eb1654e98aa99",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-02-10T15:28:04.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-11-01T20:35:25.000Z",
-      "ImageId": "ami-050c88925ffb2bb50",
-      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-02-10T15:28:04.000Z",
+            "ImageId": "ami-01d12f05657cd01d3",
+            "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0ee2eb1654e98aa99",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-02-10T15:28:04.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-02159d201cbd2cdd2",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-01T20:35:25.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2021-05-18T19:06:34.000Z",
-      "ImageId": "ami-01fc429821bf1f4b4",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-11-01T20:35:25.000Z",
+            "ImageId": "ami-050c88925ffb2bb50",
+            "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-02159d201cbd2cdd2",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-01T20:35:25.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-00a2a295179f6d875",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-05-18T19:06:34.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-09-06T18:35:26.000Z",
-      "ImageId": "ami-0c93b29195d67a0ca",
-      "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2021-05-18T19:06:34.000Z",
+            "ImageId": "ami-01fc429821bf1f4b4",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-00a2a295179f6d875",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-05-18T19:06:34.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-03283361ba297b0e6",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-06T18:35:26.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-10-07T13:43:25.000Z",
-      "ImageId": "ami-075ed2fafb0c1aa69",
-      "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-09-06T18:35:26.000Z",
+            "ImageId": "ami-0c93b29195d67a0ca",
+            "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-03283361ba297b0e6",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-06T18:35:26.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-012b883849dd3774b",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-10-07T13:43:25.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-09-01T22:41:55.000Z",
-      "ImageId": "ami-03a454637e4aa453d",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-10-07T13:43:25.000Z",
+            "ImageId": "ami-075ed2fafb0c1aa69",
+            "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-012b883849dd3774b",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-10-07T13:43:25.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a723d61baf388350",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-01T22:41:55.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-09-13T23:12:28.000Z",
-      "ImageId": "ami-07b1305cd78401892",
-      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-09-01T22:41:55.000Z",
+            "ImageId": "ami-03a454637e4aa453d",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a723d61baf388350",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-01T22:41:55.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0d41a2d81432eacab",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-09-13T23:12:28.000Z"
-    },
-    {
-      "Architecture": "arm64",
-      "CreationDate": "2022-05-05T11:09:04.000Z",
-      "ImageId": "ami-0238411fb452f8275",
-      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-09-13T23:12:28.000Z",
+            "ImageId": "ami-07b1305cd78401892",
+            "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0d41a2d81432eacab",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-09-13T23:12:28.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0221afb3433c26165",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-05-05T11:09:04.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-09-21T09:49:54.000Z",
-      "ImageId": "ami-0228302bab05078b4",
-      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "arm64",
+            "CreationDate": "2022-05-05T11:09:04.000Z",
+            "ImageId": "ami-0238411fb452f8275",
+            "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0221afb3433c26165",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-05-05T11:09:04.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0a6951fc9c80e27d6",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-21T09:49:54.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-11-04T12:58:16.000Z",
-      "ImageId": "ami-0bd50e308e4cf942a",
-      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-09-21T09:49:54.000Z",
+            "ImageId": "ami-0228302bab05078b4",
+            "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0a6951fc9c80e27d6",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-21T09:49:54.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-069584b5dccb6de20",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-11-04T12:58:16.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-11-03T18:01:07.000Z",
-      "ImageId": "ami-0bd7418456aaf76fb",
-      "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-11-04T12:58:16.000Z",
+            "ImageId": "ami-0bd50e308e4cf942a",
+            "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-069584b5dccb6de20",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-11-04T12:58:16.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0652c860378b3fce5",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-11-03T18:01:07.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2021-03-18T14:23:11.000Z",
-      "ImageId": "ami-07eeb4db5f7e5a8fb",
-      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux",
-      "UsageOperation": "RunInstances:0010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2022-11-03T18:01:07.000Z",
+            "ImageId": "ami-0bd7418456aaf76fb",
+            "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0652c860378b3fce5",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-11-03T18:01:07.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-05fff4469b5b3539c",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
-        }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2023-03-18T14:23:11.000Z"
-    },
-    {
-      "Architecture": "x86_64",
-      "CreationDate": "2022-09-06T18:59:26.000Z",
-      "ImageId": "ami-06cc9ea389270405c",
-      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-      "ImageType": "machine",
-      "Public": true,
-      "OwnerId": "309956199498",
-      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-      "UsageOperation": "RunInstances:1010",
-      "State": "available",
-      "BlockDeviceMappings": [
+            "Architecture": "x86_64",
+            "CreationDate": "2021-03-18T14:23:11.000Z",
+            "ImageId": "ami-07eeb4db5f7e5a8fb",
+            "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux",
+            "UsageOperation": "RunInstances:0010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-05fff4469b5b3539c",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2023-03-18T14:23:11.000Z"
+        },
         {
-          "DeviceName": "/dev/sda1",
-          "Ebs": {
-            "DeleteOnTermination": true,
-            "SnapshotId": "snap-0d87d9a3b83b8e663",
-            "VolumeSize": 10,
-            "VolumeType": "gp2",
-            "Encrypted": false
-          }
+            "Architecture": "x86_64",
+            "CreationDate": "2022-09-06T18:59:26.000Z",
+            "ImageId": "ami-06cc9ea389270405c",
+            "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+            "ImageType": "machine",
+            "Public": true,
+            "OwnerId": "309956199498",
+            "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+            "UsageOperation": "RunInstances:1010",
+            "State": "available",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {
+                        "DeleteOnTermination": true,
+                        "SnapshotId": "snap-0d87d9a3b83b8e663",
+                        "VolumeSize": 10,
+                        "VolumeType": "gp2",
+                        "Encrypted": false
+                    }
+                }
+            ],
+            "Description": "Provided by Red Hat, Inc.",
+            "EnaSupport": true,
+            "Hypervisor": "xen",
+            "ImageOwnerAlias": "amazon",
+            "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+            "RootDeviceName": "/dev/sda1",
+            "RootDeviceType": "ebs",
+            "SriovNetSupport": "simple",
+            "VirtualizationType": "hvm",
+            "DeprecationTime": "2024-09-06T18:59:26.000Z"
         }
-      ],
-      "Description": "Provided by Red Hat, Inc.",
-      "EnaSupport": true,
-      "Hypervisor": "xen",
-      "ImageOwnerAlias": "amazon",
-      "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-      "RootDeviceName": "/dev/sda1",
-      "RootDeviceType": "ebs",
-      "SriovNetSupport": "simple",
-      "VirtualizationType": "hvm",
-      "DeprecationTime": "2024-09-06T18:59:26.000Z"
-    }
-  ]
+    ]
 }

--- a/tests/update_images/testdata/gcp_list_images.json
+++ b/tests/update_images/testdata/gcp_list_images.json
@@ -2721,58 +2721,6 @@
   },
   {
     "architecture": "X86_64",
-    "archiveSizeBytes": "3032977152",
-    "creationTimestamp": "2022-11-28T18:53:39.376-08:00",
-    "description": "Canonical, Ubuntu, 22.04 LTS Pro Server, amd64 jammy pro server image built on 2022-11-29, supports Shielded VM features",
-    "diskSizeGb": "10",
-    "family": "ubuntu-pro-2204-lts",
-    "guestOsFeatures": [
-      {
-        "type": "VIRTIO_SCSI_MULTIQUEUE"
-      },
-      {
-        "type": "SEV_CAPABLE"
-      },
-      {
-        "type": "UEFI_COMPATIBLE"
-      },
-      {
-        "type": "GVNIC"
-      }
-    ],
-    "id": "3294347112999340764",
-    "kind": "compute#image",
-    "labelFingerprint": "42WmSpB8rSM=",
-    "licenseCodes": [
-      "2592866803419978320"
-    ],
-    "licenses": [
-      "https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2204-lts"
-    ],
-    "name": "ubuntu-pro-2204-jammy-v20221129",
-    "rawDisk": {
-      "containerType": "TAR",
-      "source": ""
-    },
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/images/ubuntu-pro-2204-jammy-v20221129",
-    "shieldedInstanceInitialState": {
-      "dbxs": [
-        {
-          "content": "2gcDBhMRFQAAAAAAAAAAABENAAAAAvEOndKvSt9o7kmKqTR9N1ZlpzCCDPUCAQExDzANBglghkgBZQMEAgEFADALBgkqhkiG9w0BBwGgggsIMIIFGDCCBACgAwIBAgITMwAAABNryScg3e1ZiAAAAAAAEzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMB4XDTE2MDEwNjE4MzQxNVoXDTE3MDQwNjE4MzQxNVowgZUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xDTALBgNVBAsTBE1PUFIxMDAuBgNVBAMTJ01pY3Jvc29mdCBXaW5kb3dzIFVFRkkgS2V5IEV4Y2hhbmdlIEtleTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKXiCkZgbboTnVZnS1h_JbnlcVst9wtFK8NQjTpeB9wirml3h-fzi8vzki0hSNBD2Dg49lGEvs4egyowmTsLu1TnBUH1f_Hi8Noa7fKXV6F93qYrTPajx5v9L7NedplWnMEPsRvJrQdrysTZwtoXMLYDhc8bQHI5nlJDfgqrB8JiC4A3vL9i19lkQOTq4PZb5AcVcE0wlG7lR_btoQN0g5B4_7pI2S_9mU1PXr1NBSEl48Kl4cJwO2GyvOVvxQ6wUSFTExmCBKrT3LnPU5lZY68n3MpZ5VY4skhrEt2dyf5bZNzkYTTouxC0n37OrMbGGq3tpv7JDD6E_Rfqua3dXYECAwEAAaOCAXIwggFuMBQGA1UdJQQNMAsGCSsGAQQBgjdPATAdBgNVHQ4EFgQUVsJIppTfox2XYoAJRIlnxAUOy2owUQYDVR0RBEowSKRGMEQxDTALBgNVBAsTBE1PUFIxMzAxBgNVBAUTKjMxNjMxKzJjNDU2Y2JjLTA1NDItNDdkOS05OWU1LWQzOWI4MTVjNTczZTAfBgNVHSMEGDAWgBRi_EPNoD6ky2cS0lvZVax7zLaKXzBTBgNVHR8ETDBKMEigRqBEhkJodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNDb3JLRUtDQTIwMTFfMjAxMS0wNi0yNC5jcmwwYAYIKwYBBQUHAQEEVDBSMFAGCCsGAQUFBzAChkRodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY0NvcktFS0NBMjAxMV8yMDExLTA2LTI0LmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCGjTFLjxsKmyLESJueg0S2Cp8N7MOq2IALsitZHwfYw2jMhY9b9kmKvIdSqVna1moZ6_zJSOS_JY6HkWZr6dDJe9Lj7xiW_e4qPP-KDrCVb02vBnK4EktVjTdJpyMhxBMdXUcq1eGl6518oCkQ27tu0-WZjaWEVsEY_gpQj0ye2UA4HYUYgJlpT24oJRi7TeQ03Nebb-ZrUkbf9uxl0OVV_mg2R5FDwOc3REoRAgv5jnw6X7ha5hlRCl2cLF27TFrFIRQQT4eSM33eDiitXXpYmD13jqKeHhLVXr07QSwqvKe1o1UYokJngP0pTwoDnt2qRuLnZ71jw732dSPN9B57MIIF6DCCA9CgAwIBAgIKYQrRiAAAAAAAAzANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjE7MDkGA1UEAxMyTWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIFJvb3QwHhcNMTEwNjI0MjA0MTI5WhcNMjYwNjI0MjA1MTI5WjCBgDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEqMCgGA1UEAxMhTWljcm9zb2Z0IENvcnBvcmF0aW9uIEtFSyBDQSAyMDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOi1ir-tVyawJsPq5_tXekQCXQcN2krldCrmsA_sbevsf7njWmMyfBEXTw7jC6c4FZOOxvXghLGamyzn9beR1gnh4sAEqKwwHN9I8wZQmmSnUX_IhU-PIIbO_i_hn_-CwO3pzc70U2piOgtDueIl_f4F-dTEFKsR4iOJjXC3pB1N7K7lnPoWwtfBy9ToxC_lme4kiwPsjfKL6sNK-0MREgt-tUeSbNzmBInr9TME6xABKnHl-YMTPP8lCS9odkb_uk--3K1xKliq-w7SeT3km2U7zCkqn_xyWaLrrpLv9jUTgMYC7ORfzJ12ze9jksGveUCEeYd_41Ko6J17B2mPFQIDAQABo4IBTzCCAUswEAYJKwYBBAGCNxUBBAMCAQAwHQYDVR0OBBYEFGL8Q82gPqTLZxLSW9lVrHvMtopfMBkGCSsGAQQBgjcUAgQMHgoAUwB1AGIAQwBBMAsGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH_MB8GA1UdIwQYMBaAFEVmUkPhflgRv9ZOniNVCDs6ImqoMFwGA1UdHwRVMFMwUaBPoE2GS2h0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9wa2kvY3JsL3Byb2R1Y3RzL01pY0NvclRoaVBhck1hclJvb18yMDEwLTEwLTA1LmNybDBgBggrBgEFBQcBAQRUMFIwUAYIKwYBBQUHMAKGRGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2kvY2VydHMvTWljQ29yVGhpUGFyTWFyUm9vXzIwMTAtMTAtMDUuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQDUhIj1FJQYAsoqPPsqkhwM16DR8ehSZqjuorV1epAAqi2kdlrqebe5N2pRexBk9uFk8gJnvveoG3i9us6IWGQM1lfIGaNfBdbbxtBpzkhLMrfrXdIw9cD1uLp4B6Mr_pvbNFaE7ILKrkElcJxr6f6QD9eWH-XnlB-yKgyNS_8oKRB799d8pdF2uQXIee0PkJKcwv7fb35sD3vUwUXdNFGWOQ_lXlbYGAWW9AemQrOgd_0IGfJxVsyfhiOkh8um_Vh-1GlnFZF-gfJ_E-UNi4o8h4Tr4869Q-WtLYSTjmorWnxE-lKqgcgtHLvgUt8AEfiaPcFgsOEztaOI0WUZChrnrHykwYKHTjixLw3FFIdv_Y0uvDm25-bD4OTNJ4TvlELvKYuQRkE7gRtn2PlDWWXLDbz9AJJP9HU7p6kk_FBBQHngLU8Kaid2blLtlml7rw_3hwXQRcKtUxSBH_swBKo3NmHaSmkbNNho7dYCz2yUDNPPbCJ5rbHwvAOiRmCpxAfCIYLx_fLoeTJgv9ispSIUS8rB2EvrfT9XNbLmT3W0sGADIlOukXkd1ptBHxWGVHCy3g01D3ywNHK6l2A78HnrorIcXaIWuIfF6Rv2tZclbzif45H6inmYw2kOt6McIAWX-MoUrgDXxPPAFBB1azSgG7WZYPNcsMVXTjbSMoS_njGCAcQwggHAAgEBMIGYMIGAMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQ29ycG9yYXRpb24gS0VLIENBIDIwMTECEzMAAAATa8knIN3tWYgAAAAAABMwDQYJYIZIAWUDBAIBBQAwDQYJKoZIhvcNAQEBBQAEggEAhabaxRIJ7nUZ-m__mIG0lII6yD-lxoeI8S83ZKTP8Qx5h5asySWl7420eGhna7zyaVRvVVIhkjOMIfcKr29LgzQpYDqPUc8aYAdGCsZKZGmHCMjEulnq5TDK79GKinzZfb2sAWXEJ68N8oNnY7faBKjHjmmJbAEz8ufE4DijgJ_NBov2xmhTZyNHQ7pB1iCdrEUGObzdJc0Qtmh3CNOEcmH0ukd8sTHE9acBBTFHS8dvreR_sP7dXClZJbJiWAFKvQn3EjCTiYizkZ4I_5xiqjHELht_ORQKN-Hnoqnl4kcRINhZRV7JlgAQDlBJLv3OTjShRO_ZWCdcu7PtwhweiSYWxMFMUJJArKlB-TaTQyiMDgAAAAAAADAAAAC9mvp3WQMyTb1gKPTnj3hLgLTZaTG_DQL9kaYeGdFPHaRS5m2yQIyoYE1BH5Jlnwq9mvp3WQMyTb1gKPTnj3hL9S-Do_qc-9aSD3IoJNvkA0U00luFByRrO5V9rG4bznq9mvp3WQMyTb1gKPTnj3hLxdnYoYbiyC0Jr6oqb38uc4cNPmT3LE4I72d5aoQPD729mvp3WQMyTb1gKPTnj3hLNjOE0U0fLgt4FWJkhMRZrVejGO9DliZgSNBYxaGbv3a9mvp3WQMyTb1gKPTnj3hLGuyEuEtsZaUSIKm-cYGWUjAhDWLW0zxImZxrKVorCga9mvp3WQMyTb1gKPTnj3hL5spo6UFGYprwP2nC-G5r72L5MLN8b7zIeLeN-YwDNOW9mvp3WQMyTb1gKPTnj3hLw6maRg2kZKBXw1htg8719K4ItxA5ee2JMnQt8O1TDGa9mvp3WQMyTb1gKPTnj3hLWPuUGu-VollDs_tfJRCg3z_kTFjJXgq4BIcpdWirl3G9mvp3WQMyTb1gKPTnj3hLU5HDovsRIQKmqh7cJa534Z9dbwnNCe6yUJkiv81Zkuq9mvp3WQMyTb1gKPTnj3hL1iYVfh1qcYvBJKuNony7ZQcsoDp7ayV9vcu9YPZe89G9mvp3WQMyTb1gKPTnj3hL0GPsKPZ-ulPxZC2_ff8zxqMq3YafYBP-Fi4sMvHL5W29mvp3WQMyTb1gKPTnj3hLKcbrUrQ8OqGLLNjtbqhgfO88-uG6_hFldVzy5hSESkS9mvp3WQMyTb1gKPTnj3hLkPvnDmnWM0CNPhcMaDLbstIJ4CclJ9-2PUnSlXKm9Ey9mvp3WQMyTb1gKPTnj3hLB17qBgWJVIugYLL-7RDaPCDH_psXzQJrlOimg7gRUji9mvp3WQMyTb1gKPTnj3hLB-bGqFhkb7HvxnkD_iixFgEfI2f-kua-KzaZnv850J69mvp3WQMyTb1gKPTnj3hLCd9fTlESCOx4uW0S0IEl_bYDho3jn29yknhSWZtlnCa9mvp3WQMyTb1gKPTnj3hLC7tDktqseribMKSsZXUxuXv6qwT5Cw2v5fm265CgY3S9mvp3WQMyTb1gKPTnj3hLDBiTOXYt8zarPdAGpGPfcVo5z7D0kkZcYA5sa9e9iYy9mvp3WQMyTb1gKPTnj3hLDQ2-ym8p7KBvMxp9cuSISxIJf7NImDoqFKDXP08QFA-9mvp3WQMyTb1gKPTnj3hLDcnz-5mWIUjDyoM2MnWNPtT8jQsAB7lbMeZSjyrNW_y9mvp3WQMyTb1gKPTnj3hLEG-s6s_s_U4wO3T0gKCAmOLQgCuTb47HdM4h8xaGaJy9mvp3WQMyTb1gKPTnj3hLF046C1tDxqYHu9NATwU0Hj3POWJnzpT4tQ4uI6nakgy9mvp3WQMyTb1gKPTnj3hLGDM0Kf8FYu2flwM-EUjc7uUtvi5JbVQQtc_WyGTS0Q-9mvp3WQMyTb1gKPTnj3hLK5nPJkIukv42X79Lww0nCGye4Ut6b_9E-y9rkAFpmTm9mvp3WQMyTb1gKPTnj3hLK78sp7jx2R8n7lK2-ypd0Em4WiubUpxdZmIGgQSwVfi9mvp3WQMyTb1gKPTnj3hLLHPZMyW6bcvlidSkxjxbk1VZ75L78FDtUMTiCFIG8X29mvp3WQMyTb1gKPTnj3hLLnCRZ4am93NRH6cYH6sPHXC1V8YyLqkjsqjTuStRr329mvp3WQMyTb1gKPTnj3hLMGYo-lR3MFcoukpGfefQOHpU9WnTdp_OXnXsidKNFZO9mvp3WQMyTb1gKPTnj3hLNgjtuvWtD0GkFKF3er8vr15nAzRnXsOZXmk1gp4MqtK9mvp3WQMyTb1gKPTnj3hLOEHSITaNFYPXXAoC5iFgOU1sTgpnYLb2B7kDYryFWwK9mvp3WQMyTb1gKPTnj3hLP86bn98-8J1UUrD5XuSBwrfwbXQ6c3lxVY5wE2rOPnO9mvp3WQMyTb1gKPTnj3hLQ5fayoOef2MHfLUMkt9DvC0vsqj1nyb8eg5L1Nl1FpK9mvp3WQMyTb1gKPTnj3hLR8wIYSfiBpqG4Dpr7yzUEPjFWm1r2zYhaMMbLOMqWt-9mvp3WQMyTb1gKPTnj3hLUYgx_nOCtRTQPhXGISKLirZUeb0Mv6PFwdD0jZwwYTW9mvp3WQMyTb1gKPTnj3hLWulJ6ohV65PkOdvGW9ouQoUsL99nifoUZzbjw0EPK1y9mvp3WQMyTb1gKPTnj3hLax0TgHjkQYqmjet7s14GYJLPR57rjOTNEufQcsy0L2a9mvp3WQMyTb1gKPTnj3hLbIhUR43VWeKTUbgmwGy4v-8rlK01ODWHctGT-C7RyhG9mvp3WQMyTb1gKPTnj3hLbxQo_3HJ2w7Vrx8ue7_Lq2R8wmXd9bKTzbYm9Qo6eF69mvp3WQMyTb1gKPTnj3hLcfKQb9IiSX5Uo0ZiqySX_MgQIHcP9RNo6ePZv8v9Y3W9mvp3WQMyTb1gKPTnj3hLcms-tlQEajDz-D2bls4D9nDpqAbRcIoDceYtxJ0sI8G9mvp3WQMyTb1gKPTnj3hLcuC9GGfPXZ1WqxWK3zvdvIK_MqjYqh2MXi9t8pQo1ti9mvp3WQMyTb1gKPTnj3hLeCevmTYs-vBxfa3ksb_gQ4rRccFa3cJIt1v4yqRLssW9mvp3WQMyTb1gKPTnj3hLgai5ZbuE04drlCmpVIHMlVMYz6oUEtgIyKM7_TP_8OS9mvp3WQMyTb1gKPTnj3hLgts7zrT2CEPOnZfD0YfNm1lBzT3oEA5YbyvaVjdXX2e9mvp3WQMyTb1gKPTnj3hLiVqXhfYXyh1-1E_BoUcLcfPxIjhi2f-dzDri35IWPa-9mvp3WQMyTb1gKPTnj3hLitZIWfGVtfWNr6qUC2phZ6zWeohuj0aTZBdyIcVZRbm9mvp3WQMyTb1gKPTnj3hLi_Q0tJ4AzPcVAqLNkAhlywHsOz2gPDW-UF_fe9Vj9SG9mvp3WQMyTb1gKPTnj3hLjY6iic_nChwHq3NlyyjuUe3TPPJQbeiI-63WDr-ASBy9mvp3WQMyTb1gKPTnj3hLmZjTY8SRvha9dLoQuU2SkQAWEXNv3KZDo2ZkvA8xWkK9mvp3WQMyTb1gKPTnj3hLnkppFzFhaC5V_ej-9WDriOwf_tyvBAAfZsDK9weytzS9mvp3WQMyTb1gKPTnj3hLprUVHzZV06KvDUcnWXlr5KQgDlSVp9hpdUxISIV0CKe9mvp3WQMyTb1gKPTnj3hLp_MvUI1OsP6tmgh--U7RugrsXeb372_wpiuTvt9dRY29mvp3WQMyTb1gKPTnj3hLrWgm4ZRtJtPq82hciNl9hd47Tcs9DuKugccFYNE8VyC9mvp3WQMyTb1gKPTnj3hLruuuMVEnEnPtlaouZxE57TGphWcwOjMimPg3CanVWqG9mvp3WQMyTb1gKPTnj3hLr-IDCvt9LNoT-fozOgLjT2dRr-wRsBDbzUQf30xAArO9mvp3WQMyTb1gKPTnj3hLtU8e5jZjH61oBY07CTcDGsG5DMsXBio5HMpor9vkDVW9mvp3WQMyTb1gKPTnj3hLuPB42YOiSsQzIWOTiDUUzZMsM68Y591wiEyCNfQnVza9mvp3WQMyTb1gKPTnj3hLuXoIiQWcA1_x1UtttTsRuXZmaNn5VSR8AosoN9egTNm9mvp3WQMyTb1gKPTnj3hLvIemaOgZZkictQjugFGDwZ5qzSTPF3mcoGLS44TaDqe9mvp3WQMyTb1gKPTnj3hLxAm9rEd1rdjbkqoitbcY-4yUoUYsH-mkFrldijOIwvy9mvp3WQMyTb1gKPTnj3hLxhfBqLHuKoEcKLWoG0yD18mLWwwnKB1hAgfr5pLCln-9mvp3WQMyTb1gKPTnj3hLyQ8zZhe45_mDl1QTyZfxC3PrJn_YoQy5472_xmer24u9mvp3WQMyTb1gKPTnj3hLy2uFi0DToJh2WBW1ksFRSklgT6_WCBnaiNenbpd4_ve9mvp3WQMyTb1gKPTnj3hLzjv6vlnWfOisjf1KFvfEPvnCJFE_vGVZV9c1-in1QM69mvp3WQMyTb1gKPTnj3hL2MvrlzX1Zys2fk-WzcdJaWFdFwdK6WxyTULOAhb48_q9mvp3WQMyTb1gKPTnj3hL6Swi6ztWQtZcHsLK8kfSWUc47rt_s4QaRJVvWeKw0fq9mvp3WQMyTb1gKPTnj3hL_d1uPSnqhMd0Pa1KG9vHALX-wbOR-TJAkIasxx3W29i9mvp3WQMyTb1gKPTnj3hL_mOoT3gsydP88sz5_BH70Ddgh4dY0mKF7RJmm9xubQG9mvp3WQMyTb1gKPTnj3hL_s-yMtEumUttSF0scWdyiqVSWYStXKYedRYiHweaFDa9mvp3WQMyTb1gKPTnj3hLyhcdYUqNfhIck5SM0P5V05mB-dEaqW4DRQpBUifCxlu9mvp3WQMyTb1gKPTnj3hLVbmbDeU9vP5IWqnHN88_thbvPZH6tZmqfKsZ7adjtbq9mvp3WQMyTb1gKPTnj3hLd90ZD6MNiP9eOwEaCuYeYgl4DBMLU17Lh-bwiIoLay-9mvp3WQMyTb1gKPTnj3hLyDyxOSKtmfVgdEZ13TfMlNytWh_Lpkcv7jQRcdk56IS9mvp3WQMyTb1gKPTnj3hLOwKHUz4Mw9DsGqgjy_CpQarYchV50cSZgC3Rw6Y2uKm9mvp3WQMyTb1gKPTnj3hLk5ru9PX6UeIzQMPy5JBIzohyUmr991LDp_Oj8ryfYEm9mvp3WQMyTb1gKPTnj3hLZFdb2RJ4mi4UrVb2NB9Sr2v4DPlEAHhZdenwTi1k10W9mvp3WQMyTb1gKPTnj3hLRcfIrnUKz7tI_DdSfWQS3WRNrtiRPM2KJMlNhWln344=",
-          "fileType": "BIN"
-        }
-      ]
-    },
-    "sourceType": "RAW",
-    "status": "READY",
-    "storageLocations": [
-      "us",
-      "eu",
-      "asia"
-    ]
-  },
-  {
-    "architecture": "X86_64",
     "archiveSizeBytes": "2461893312",
     "creationTimestamp": "2022-11-17T10:48:14.961-08:00",
     "description": "Canonical, Ubuntu, 18.04 LTS Pro FIPS Server, amd64 bionic pro fips server image built on 2022-11-17, supports Shielded VM features",
@@ -5281,9 +5229,9 @@
     ]
   },
   {
-    "archiveSizeBytes": "2583054144",
-    "creationTimestamp": "2022-11-28T13:23:34.955-08:00",
-    "description": "Fedora, Fedora CoreOS stable, 37.20221106.3.0, x86_64 published on 2022-11-28",
+    "archiveSizeBytes": "2593323456",
+    "creationTimestamp": "2022-11-11T08:50:58.455-08:00",
+    "description": "Fedora, Fedora CoreOS stable, 36.20221030.3.0, x86_64 published on 2022-11-11",
     "diskSizeGb": "10",
     "family": "fedora-coreos-stable",
     "guestOsFeatures": [
@@ -5294,7 +5242,7 @@
         "type": "UEFI_COMPATIBLE"
       }
     ],
-    "id": "5351538346435319865",
+    "id": "4067408876595823517",
     "kind": "compute#image",
     "labelFingerprint": "42WmSpB8rSM=",
     "licenseCodes": [
@@ -5305,63 +5253,24 @@
       "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/licenses/fedora-coreos-stable",
       "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
     ],
-    "name": "fedora-coreos-37-20221106-3-0-gcp-x86-64",
+    "name": "fedora-coreos-36-20221030-3-0-gcp-x86-64",
     "rawDisk": {
       "containerType": "TAR",
       "source": ""
     },
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20221106-3-0-gcp-x86-64",
-    "sourceType": "RAW",
-    "status": "READY",
-    "storageLocations": [
-      "us",
-      "asia",
-      "eu"
-    ]
-  },
-  {
-    "archiveSizeBytes": "2447184576",
-    "creationTimestamp": "2022-11-28T03:17:39.153-08:00",
-    "description": "Fedora, Fedora CoreOS next, 37.20221127.1.0, x86_64 published on 2022-11-28",
-    "diskSizeGb": "10",
-    "family": "fedora-coreos-next",
-    "guestOsFeatures": [
-      {
-        "type": "VIRTIO_SCSI_MULTIQUEUE"
-      },
-      {
-        "type": "UEFI_COMPATIBLE"
-      }
-    ],
-    "id": "8584080559044109885",
-    "kind": "compute#image",
-    "labelFingerprint": "42WmSpB8rSM=",
-    "licenseCodes": [
-      "8565510459461902525",
-      "1002001"
-    ],
-    "licenses": [
-      "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/licenses/fedora-coreos-next",
-      "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
-    ],
-    "name": "fedora-coreos-37-20221127-1-0-gcp-x86-64",
-    "rawDisk": {
-      "containerType": "TAR",
-      "source": ""
-    },
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20221127-1-0-gcp-x86-64",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-36-20221030-3-0-gcp-x86-64",
     "sourceType": "RAW",
     "status": "READY",
     "storageLocations": [
       "eu",
-      "us",
-      "asia"
+      "asia",
+      "us"
     ]
   },
   {
-    "archiveSizeBytes": "2447144832",
-    "creationTimestamp": "2022-11-28T05:33:05.877-08:00",
-    "description": "Fedora, Fedora CoreOS testing, 37.20221127.2.0, x86_64 published on 2022-11-28",
+    "archiveSizeBytes": "2509172736",
+    "creationTimestamp": "2022-11-11T10:46:03.532-08:00",
+    "description": "Fedora, Fedora CoreOS testing, 37.20221106.2.1, x86_64 published on 2022-11-11",
     "diskSizeGb": "10",
     "family": "fedora-coreos-testing",
     "guestOsFeatures": [
@@ -5372,7 +5281,7 @@
         "type": "UEFI_COMPATIBLE"
       }
     ],
-    "id": "1352207264465356414",
+    "id": "5998746912445113988",
     "kind": "compute#image",
     "labelFingerprint": "42WmSpB8rSM=",
     "licenseCodes": [
@@ -5383,18 +5292,57 @@
       "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/licenses/fedora-coreos-testing",
       "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
     ],
-    "name": "fedora-coreos-37-20221127-2-0-gcp-x86-64",
+    "name": "fedora-coreos-37-20221106-2-1-gcp-x86-64",
     "rawDisk": {
       "containerType": "TAR",
       "source": ""
     },
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20221127-2-0-gcp-x86-64",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20221106-2-1-gcp-x86-64",
     "sourceType": "RAW",
     "status": "READY",
     "storageLocations": [
-      "asia",
       "us",
-      "eu"
+      "eu",
+      "asia"
+    ]
+  },
+  {
+    "archiveSizeBytes": "2509803840",
+    "creationTimestamp": "2022-11-14T13:35:05.232-08:00",
+    "description": "Fedora, Fedora CoreOS next, 37.20221111.1.0, x86_64 published on 2022-11-14",
+    "diskSizeGb": "10",
+    "family": "fedora-coreos-next",
+    "guestOsFeatures": [
+      {
+        "type": "VIRTIO_SCSI_MULTIQUEUE"
+      },
+      {
+        "type": "UEFI_COMPATIBLE"
+      }
+    ],
+    "id": "6909213806637812327",
+    "kind": "compute#image",
+    "labelFingerprint": "42WmSpB8rSM=",
+    "licenseCodes": [
+      "8565510459461902525",
+      "1002001"
+    ],
+    "licenses": [
+      "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/licenses/fedora-coreos-next",
+      "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+    ],
+    "name": "fedora-coreos-37-20221111-1-0-gcp-x86-64",
+    "rawDisk": {
+      "containerType": "TAR",
+      "source": ""
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20221111-1-0-gcp-x86-64",
+    "sourceType": "RAW",
+    "status": "READY",
+    "storageLocations": [
+      "us",
+      "eu",
+      "asia"
     ]
   },
   {


### PR DESCRIPTION
Reverts redhatcloudx/rhelocator#163

I would like to skip this update until #117 is merged - to avoid merge conflicts