### PR TITLE
Make renovate update the lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "rangeStrategy": "update-lockfile"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "config:base"
   ],
-  "rangeStrategy": "update-lockfile"
+  "rangeStrategy": "update-lockfile",
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
Renovate's default `rangeStrategy` setting is `replace`. That only updates the pyproject.toml if the new version upstream is outside the range of what pyproject.toml will allow.

By using `update-lockfile` instead, renovate instead updates the lockfile when dependencies change within ranges and then updates the ranges (similar to `replace`) when the ranges change.

https://docs.renovatebot.com/configuration-options/#rangestrategy

Signed-off-by: Major Hayden <major@redhat.com>