### PR TITLE
Container Release: Replace poetry with release install

### DIFF
--- a/.github/workflows/container_release.yaml
+++ b/.github/workflows/container_release.yaml
@@ -81,6 +81,10 @@ jobs:
           jq -s 'reduce .[] as $item ({}; . * $item)' ./data/* >> ./data/image-data.json
           rm ./data/temp*.json
 
+      - name: Build rhelocator release
+        run: |
+          poetry build -f wheel
+
       - name: Build API container
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/Containerfile
+++ b/Containerfile
@@ -1,16 +1,12 @@
 FROM python:3.10-alpine
 
-COPY . /opt/rhelocator/
+COPY ./dist/*.whl /opt/rhelocator/
+COPY ./data/image-data.json /opt/rhelocator/
 WORKDIR /opt/rhelocator
 
 RUN apk update \
     && apk --no-cache --update add build-base
 
-ENV POETRY_VERSION=1.2.1
+RUN pip install ./*.whl
 
-RUN pip install "poetry==$POETRY_VERSION"
-
-RUN poetry config virtualenvs.create false
-RUN poetry install --only main --no-interaction --no-ansi
-
-CMD ["poetry", "run", "rhelocator-updater", "serve", "--file-path", "/opt/rhelocator/data/image-data.json"]
+CMD ["rhelocator-updater", "serve", "--file-path", "/opt/rhelocator/image-data.json"]


### PR DESCRIPTION
Remove poetry dependencies from Containerfile and replace it with release install.
Add rhelocator build stage to release workflow.

Closes #204 