### PR TITLE
Add external product to AWS and Google image names

### DIFF
--- a/src/rhelocator/update_images/aws.py
+++ b/src/rhelocator/update_images/aws.py
@@ -162,9 +162,9 @@ def format_image(image: dict[str, str], region: str) -> dict[str, str]:
     billing = additional_information["billing"]
     extprod = additional_information["extprod"]
     intprod = additional_information["intprod"]
-    name_parts = ['RHEL', version, intprod, extprod, virt_type, arch, billing, beta]
+    name_parts = ["RHEL", version, intprod, extprod, virt_type, arch, billing, beta]
 
-    name = ' '.join([x for x in name_parts if x != ''])
+    name = " ".join([x for x in name_parts if x != ""])
     selflink = (
         f"https://console.aws.amazon.com/ec2/home?region={region}#launchAmi={image_id}"
     )
@@ -179,4 +179,3 @@ def format_image(image: dict[str, str], region: str) -> dict[str, str]:
         "selflink": selflink,
         "region": region,
     }
-

--- a/src/rhelocator/update_images/aws.py
+++ b/src/rhelocator/update_images/aws.py
@@ -160,8 +160,11 @@ def format_image(image: dict[str, str], region: str) -> dict[str, str]:
     version = additional_information["version"]
     beta = additional_information["beta"]
     billing = additional_information["billing"]
+    extprod = additional_information["extprod"]
+    intprod = additional_information["intprod"]
+    name_parts = ['RHEL', version, intprod, extprod, virt_type, arch, billing, beta]
 
-    name = f"RHEL {version} {virt_type} {arch} {billing} {beta}"
+    name = ' '.join([x for x in name_parts if x != ''])
     selflink = (
         f"https://console.aws.amazon.com/ec2/home?region={region}#launchAmi={image_id}"
     )
@@ -176,3 +179,4 @@ def format_image(image: dict[str, str], region: str) -> dict[str, str]:
         "selflink": selflink,
         "region": region,
     }
+

--- a/src/rhelocator/update_images/google.py
+++ b/src/rhelocator/update_images/google.py
@@ -68,30 +68,28 @@ def normalize_google_images(image_list: list[Any]) -> list[dict[str, str]]:
     return normalized_images
 
 
-def parse_image_version_from_name(image_name: str) -> str:
+def parse_image_name(image_name: str) -> dict[str, str]:
     """Parse an google image name and return version string.
 
-    Regex101: https://regex101.com/r/CiABs5/1
+    Regex101: https://regex101.com/r/9QCWIJ/1
 
     Args:
         image_name: String containing the image name, such as:
                     rhel-7-9-sap-v20220719
 
     Returns:
-        Returns the google image version as string
-                    rhel-7-9
+        Dictionary with additional information about the image.
     """
     google_image_name_regex = (
         r"(?P<product>\w*)-(?P<version>[\d]+(?:\-[\d]){0,3})-?"
-        r"(?P<intprod>\w*)?-v(?P<date>\d{4}\d{2}\d{2})"
+        r"(?P<extprod>\w*)?-v(?P<date>\d{4}\d{2}\d{2})"
     )
 
     matches = re.match(google_image_name_regex, image_name, re.IGNORECASE)
     if matches:
-        image_data = matches.groupdict()
-        version = image_data["version"]
-        return version.replace("-", ".")
-    return "unknown"
+        return matches.groupdict()
+
+    return {}
 
 
 def format_all_images() -> object:
@@ -121,13 +119,26 @@ def format_image(image: dict[str, str]) -> dict[str, str]:
         JSON like structure containing streamlined image
         information.
     """
+    additional_information = parse_image_name(image["name"])
 
     arch = image["architecture"]
     image_id = image["name"]
     date = image["creation_timestamp"]
-    version = parse_image_version_from_name(image["name"])
+    extprod = additional_information["extprod"]
+    version = additional_information["version"].replace("-", ".")
 
-    name = f"RHEL {version} {arch}"
+    name_parts = ['RHEL', version, extprod]
+
+    # This is necessary to avoid creating names like "RHEL 9 arm64 arm64"
+    # as the naming conventions for Google images are inconsistent.
+    # e.g.
+    # rhel-9-arm64-v20221206
+    # rhel-7-6-sap-v20221102
+    if extprod.lower() != arch.lower():
+      name_parts.append(arch)
+
+    name = ' '.join([x for x in name_parts if x != ''])
+
     selflink = "https://console.cloud.google.com/compute/imagesDetail/"
     selflink += f"projects/rhel-cloud/global/images/{image_id}"
 

--- a/src/rhelocator/update_images/google.py
+++ b/src/rhelocator/update_images/google.py
@@ -127,7 +127,7 @@ def format_image(image: dict[str, str]) -> dict[str, str]:
     extprod = additional_information["extprod"]
     version = additional_information["version"].replace("-", ".")
 
-    name_parts = ['RHEL', version, extprod]
+    name_parts = ["RHEL", version, extprod]
 
     # This is necessary to avoid creating names like "RHEL 9 arm64 arm64"
     # as the naming conventions for Google images are inconsistent.
@@ -135,9 +135,9 @@ def format_image(image: dict[str, str]) -> dict[str, str]:
     # rhel-9-arm64-v20221206
     # rhel-7-6-sap-v20221102
     if extprod.lower() != arch.lower():
-      name_parts.append(arch)
+        name_parts.append(arch)
 
-    name = ' '.join([x for x in name_parts if x != ''])
+    name = " ".join([x for x in name_parts if x != ""])
 
     selflink = "https://console.cloud.google.com/compute/imagesDetail/"
     selflink += f"projects/rhel-cloud/global/images/{image_id}"

--- a/tests/update_images/test_aws.py
+++ b/tests/update_images/test_aws.py
@@ -169,6 +169,13 @@ def test_parse_image_name_external_product():
     assert data["storage"] == "GP2"
 
 
+def test_parse_invalid_image_name():
+    """Test parsing an AWS invalid image name."""
+    image_name = "thisisnotarealname"
+    data = aws.parse_image_name(image_name)
+
+    assert not data
+
 def test_format_image():
     """Test transforming a single AWS image into a schema approved format."""
     mocked_image = {

--- a/tests/update_images/test_aws.py
+++ b/tests/update_images/test_aws.py
@@ -176,6 +176,7 @@ def test_parse_invalid_image_name():
 
     assert not data
 
+
 def test_format_image():
     """Test transforming a single AWS image into a schema approved format."""
     mocked_image = {

--- a/tests/update_images/test_google.py
+++ b/tests/update_images/test_google.py
@@ -112,9 +112,10 @@ def test_format_image():
     except ValidationError as exc:
         raise AssertionError(f"Formatted data does not expect schema: {exc}")
 
+
 def test_format_image_with_arch_in_name():
-    """Test transforming a single google image into a schema approved
-    format if name contains architecture instead of external product."""
+    """Test transforming a single google image into a schema approved format if
+    name contains architecture instead of external product."""
     mocked_image = {
         "id": "3359998819149417250",
         "architecture": "ARM64",


### PR DESCRIPTION
Add the external product as a part of the image name.
Adding missing tests to get back to 100% code coverage on AWS and Google update_image methods.

Azure already includes the external product in their image names.
