### PR TITLE
Fix aws image sorting

### DIFF
--- a/tests/update_images/testdata/aws_list_images.json
+++ b/tests/update_images/testdata/aws_list_images.json
@@ -1,1974 +1,1976 @@
-[
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2020-12-22T21:41:45.000Z",
-    "ImageId": "ami-0698b90665a2ddcf1",
-    "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-03c1cdd933e8e0388",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+{
+  "Images": [
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2020-12-22T21:41:45.000Z",
+      "ImageId": "ami-0698b90665a2ddcf1",
+      "ImageLocation": "amazon/RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03c1cdd933e8e0388",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2022-12-22T21:41:45.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-02-09T09:46:19.000Z",
-    "ImageId": "ami-030e754805234517e",
-    "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-06558552e58534568",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3.0_HVM-20201222-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2022-12-22T21:41:45.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-02-09T09:46:19.000Z",
+      "ImageId": "ami-030e754805234517e",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-06558552e58534568",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-02-09T09:46:19.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-02-10T15:28:04.000Z",
-    "ImageId": "ami-01d12f05657cd01d3",
-    "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0ee2eb1654e98aa99",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-09T09:46:19.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-02-10T15:28:04.000Z",
+      "ImageId": "ami-01d12f05657cd01d3",
+      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ee2eb1654e98aa99",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-02-10T15:28:04.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-02-10T16:09:34.000Z",
-    "ImageId": "ami-0846f86a5c7cb6d25",
-    "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a3e344c66212c494",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-10T15:28:04.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-02-10T16:09:34.000Z",
+      "ImageId": "ami-0846f86a5c7cb6d25",
+      "ImageLocation": "amazon/RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a3e344c66212c494",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-02-10T16:09:34.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-03-18T14:23:11.000Z",
-    "ImageId": "ami-07eeb4db5f7e5a8fb",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-05fff4469b5b3539c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.3_HVM-20210209-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-02-10T16:09:34.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-18T14:23:11.000Z",
+      "ImageId": "ami-07eeb4db5f7e5a8fb",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-05fff4469b5b3539c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-03-18T14:23:11.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-03-18T14:30:58.000Z",
-    "ImageId": "ami-0a47672f6c7827dd2",
-    "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0d4a229075ac98ffe",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:23:11.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-18T14:30:58.000Z",
+      "ImageId": "ami-0a47672f6c7827dd2",
+      "ImageLocation": "amazon/RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d4a229075ac98ffe",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": false,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-03-18T14:30:58.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-03-18T14:38:28.000Z",
-    "ImageId": "ami-069d22ec49577d4bf",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0537803fe544b6657",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": false,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-6.10_HVM-20210318-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:30:58.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-03-18T14:38:28.000Z",
+      "ImageId": "ami-069d22ec49577d4bf",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0537803fe544b6657",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-03-18T14:38:28.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-03-22T22:48:11.000Z",
-    "ImageId": "ami-03e95cf9553d62e4e",
-    "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-098e254b866bbbf84",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-18T14:38:28.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-22T22:48:11.000Z",
+      "ImageId": "ami-03e95cf9553d62e4e",
+      "ImageLocation": "amazon/RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-098e254b866bbbf84",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-03-22T22:48:11.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-03-22T23:07:45.000Z",
-    "ImageId": "ami-098453baf108a57d0",
-    "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0539db0c36394a20c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.3_HVM-20210315-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-22T22:48:11.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-03-22T23:07:45.000Z",
+      "ImageId": "ami-098453baf108a57d0",
+      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0539db0c36394a20c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-03-22T23:07:45.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-05-18T18:45:41.000Z",
-    "ImageId": "ami-02e0bb36c61bb9715",
-    "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-09cef070be51e0d54",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-7.9_HVM-20210315-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-03-22T23:07:45.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-05-18T18:45:41.000Z",
+      "ImageId": "ami-02e0bb36c61bb9715",
+      "ImageLocation": "amazon/RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-09cef070be51e0d54",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-05-18T18:45:41.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-05-18T19:06:34.000Z",
-    "ImageId": "ami-01fc429821bf1f4b4",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-00a2a295179f6d875",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T18:45:41.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-05-18T19:06:34.000Z",
+      "ImageId": "ami-01fc429821bf1f4b4",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00a2a295179f6d875",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-05-18T19:06:34.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-05-18T20:09:47.000Z",
-    "ImageId": "ami-0b0af3577fe5e3532",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-03a3ad00558b4d17c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T19:06:34.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-05-18T20:09:47.000Z",
+      "ImageId": "ami-0b0af3577fe5e3532",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03a3ad00558b4d17c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-05-18T20:09:47.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-09-01T22:41:55.000Z",
-    "ImageId": "ami-03a454637e4aa453d",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a723d61baf388350",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-05-18T20:09:47.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-01T22:41:55.000Z",
+      "ImageId": "ami-03a454637e4aa453d",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a723d61baf388350",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-01T22:41:55.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-09-01T22:42:25.000Z",
-    "ImageId": "ami-00c2075e4c33c96b1",
-    "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0772e3d6ab0e668f9",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-01T22:41:55.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-01T22:42:25.000Z",
+      "ImageId": "ami-00c2075e4c33c96b1",
+      "ImageLocation": "amazon/RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0772e3d6ab0e668f9",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-01T22:42:25.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-09-13T23:12:28.000Z",
-    "ImageId": "ami-07b1305cd78401892",
-    "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0d41a2d81432eacab",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.4.0_HVM-20210825-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-01T22:42:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-13T23:12:28.000Z",
+      "ImageId": "ami-07b1305cd78401892",
+      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d41a2d81432eacab",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-13T23:12:28.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-09-13T23:15:20.000Z",
-    "ImageId": "ami-04d5b6962825b6f92",
-    "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-021290819a3011ff6",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.1.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-13T23:12:28.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-13T23:15:20.000Z",
+      "ImageId": "ami-04d5b6962825b6f92",
+      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-021290819a3011ff6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-13T23:15:20.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-09-14T00:51:06.000Z",
-    "ImageId": "ami-02a393af854e372cc",
-    "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0473eebd0ff3d5c03",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.2.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-13T23:15:20.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-14T00:51:06.000Z",
+      "ImageId": "ami-02a393af854e372cc",
+      "ImageLocation": "amazon/RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0473eebd0ff3d5c03",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-14T00:51:06.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-09-14T00:53:52.000Z",
-    "ImageId": "ami-03951dc3553ee499f",
-    "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0b6fba19dbdc3e202",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.1.0_HVM-20210907-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-14T00:51:06.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-14T00:53:52.000Z",
+      "ImageId": "ami-03951dc3553ee499f",
+      "ImageLocation": "amazon/RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b6fba19dbdc3e202",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-14T00:53:52.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-09-29T16:34:35.000Z",
-    "ImageId": "ami-0fee3e66d33ee0f06",
-    "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0b1fa9ca91fbb0b68",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.2.0_HVM-20210907-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-14T00:53:52.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-09-29T16:34:35.000Z",
+      "ImageId": "ami-0fee3e66d33ee0f06",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b1fa9ca91fbb0b68",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-29T16:34:35.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-09-29T17:02:36.000Z",
-    "ImageId": "ami-01bc2c0b484a594b6",
-    "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-02f6c8dde2ba5da81",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM_BETA-20210902-arm64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T16:34:35.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-29T17:02:36.000Z",
+      "ImageId": "ami-01bc2c0b484a594b6",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02f6c8dde2ba5da81",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-29T17:02:36.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-09-29T19:05:02.000Z",
-    "ImageId": "ami-07b828c02eecf97a0",
-    "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-055d424edd1ba54a3",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T17:02:36.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-09-29T19:05:02.000Z",
+      "ImageId": "ami-07b828c02eecf97a0",
+      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-055d424edd1ba54a3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-09-29T19:05:02.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-10-07T13:43:25.000Z",
-    "ImageId": "ami-075ed2fafb0c1aa69",
-    "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-012b883849dd3774b",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5.0_HVM_BETA-20210902-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-09-29T19:05:02.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-07T13:43:25.000Z",
+      "ImageId": "ami-075ed2fafb0c1aa69",
+      "ImageLocation": "amazon/RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-012b883849dd3774b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-10-07T13:43:25.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-10-07T13:46:54.000Z",
-    "ImageId": "ami-0706d92706869e46f",
-    "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-00ba72d56dfca4804",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-SAP-8.1.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-07T13:43:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-07T13:46:54.000Z",
+      "ImageId": "ami-0706d92706869e46f",
+      "ImageLocation": "amazon/RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00ba72d56dfca4804",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-10-07T13:46:54.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-10-11T15:52:18.000Z",
-    "ImageId": "ami-073955d8665a7a9e7",
-    "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-04dbc853e93a60050",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-SAP-8.2.0_HVM-20211007-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-07T13:46:54.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-11T15:52:18.000Z",
+      "ImageId": "ami-073955d8665a7a9e7",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-04dbc853e93a60050",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-10-11T15:52:18.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-10-27T22:12:53.000Z",
-    "ImageId": "ami-00e69c1911063647b",
-    "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0cda51e2c43f39bb4",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20211005-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-11T15:52:18.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-10-27T22:12:53.000Z",
+      "ImageId": "ami-00e69c1911063647b",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0cda51e2c43f39bb4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-10-27T22:12:53.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-11-02T15:07:35.000Z",
-    "ImageId": "ami-0fb33ec3ead0b8e3f",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a7d67fe617f7fc7c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-10-27T22:12:53.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-02T15:07:35.000Z",
+      "ImageId": "ami-0fb33ec3ead0b8e3f",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a7d67fe617f7fc7c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-11-02T15:07:35.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-11-02T15:33:24.000Z",
-    "ImageId": "ami-011598171b609aa36",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-02c94d9b8caa7d16c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-02T15:07:35.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-11-02T15:33:24.000Z",
+      "ImageId": "ami-011598171b609aa36",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02c94d9b8caa7d16c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-11-02T15:33:24.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2021-11-04T11:39:13.000Z",
-    "ImageId": "ami-0dcff282af898b064",
-    "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-01a88a547081205b3",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM_BETA-20211026-arm64-10-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-02T15:33:24.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2021-11-04T11:39:13.000Z",
+      "ImageId": "ami-0dcff282af898b064",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-01a88a547081205b3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-11-04T11:39:13.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-11-04T12:54:23.000Z",
-    "ImageId": "ami-06644055bed38ebd9",
-    "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-081fdba618fb27010",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM-20211103-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T11:39:13.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-04T12:54:23.000Z",
+      "ImageId": "ami-06644055bed38ebd9",
+      "ImageLocation": "amazon/RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-081fdba618fb27010",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-11-04T12:54:23.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2021-11-04T12:58:16.000Z",
-    "ImageId": "ami-0bd50e308e4cf942a",
-    "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-069584b5dccb6de20",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T12:54:23.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2021-11-04T12:58:16.000Z",
+      "ImageId": "ami-0bd50e308e4cf942a",
+      "ImageLocation": "amazon/RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-069584b5dccb6de20",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2023-11-04T12:58:16.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-02-01T22:03:37.000Z",
-    "ImageId": "ami-019599717e2dd5baa",
-    "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a3283a4c18f1873e",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5.0_HVM-20211103-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2023-11-04T12:58:16.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-01T22:03:37.000Z",
+      "ImageId": "ami-019599717e2dd5baa",
+      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a3283a4c18f1873e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-02-01T22:03:37.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-02-01T22:35:37.000Z",
-    "ImageId": "ami-05a407c8573ef7269",
-    "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-074f0b737ea45a35b",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:03:37.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-02-01T22:35:37.000Z",
+      "ImageId": "ami-05a407c8573ef7269",
+      "ImageLocation": "amazon/RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-074f0b737ea45a35b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-02-01T22:35:37.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-02-01T22:41:13.000Z",
-    "ImageId": "ami-0f095f89ae15be883",
-    "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-06e7cbd0bd9e9885b",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.5_HVM-20220127-arm64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:35:37.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-01T22:41:13.000Z",
+      "ImageId": "ami-0f095f89ae15be883",
+      "ImageLocation": "amazon/RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-06e7cbd0bd9e9885b",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-02-01T22:41:13.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-02-22T19:11:17.000Z",
-    "ImageId": "ami-0051b1b2c5a166c8c",
-    "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0aad058902479a1c1",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.5_HVM-20220127-x86_64-3-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-01T22:41:13.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-02-22T19:11:17.000Z",
+      "ImageId": "ami-0051b1b2c5a166c8c",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0aad058902479a1c1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-02-22T19:11:17.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-03-23T17:34:47.000Z",
-    "ImageId": "ami-05b640d310801a144",
-    "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0ad23efbfca7c1977",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20220222-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-02-22T19:11:17.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-03-23T17:34:47.000Z",
+      "ImageId": "ami-05b640d310801a144",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ad23efbfca7c1977",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-03-23T17:34:47.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-03-23T19:53:26.000Z",
-    "ImageId": "ami-073c570ae7a0977cb",
-    "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0f42712d5d7ceb2a4",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM_BETA-20220302-arm64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-03-23T17:34:47.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-03-23T19:53:26.000Z",
+      "ImageId": "ami-073c570ae7a0977cb",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0f42712d5d7ceb2a4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-03-23T19:53:26.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-05-05T09:32:29.000Z",
-    "ImageId": "ami-06640050dc3f556bb",
-    "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0ebc25e8422901c8e",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM_BETA-20220302-x86_64-5-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-03-23T19:53:26.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-05T09:32:29.000Z",
+      "ImageId": "ami-06640050dc3f556bb",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ebc25e8422901c8e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-05-05T09:32:29.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-05-05T11:09:04.000Z",
-    "ImageId": "ami-0238411fb452f8275",
-    "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0221afb3433c26165",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-05T09:32:29.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-05-05T11:09:04.000Z",
+      "ImageId": "ami-0238411fb452f8275",
+      "ImageLocation": "amazon/RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0221afb3433c26165",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-05-05T11:09:04.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-05-13T11:21:52.000Z",
-    "ImageId": "ami-0c41531b8d18cc72b",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-073f8b28002570466",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.6.0_HVM-20220503-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-05T11:09:04.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-13T11:21:52.000Z",
+      "ImageId": "ami-0c41531b8d18cc72b",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-073f8b28002570466",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-05-13T11:21:52.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-05-13T12:04:49.000Z",
-    "ImageId": "ami-08ddbe20d7e0d2f8f",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0af47e5c98135e3c4",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-13T11:21:52.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-05-13T12:04:49.000Z",
+      "ImageId": "ami-08ddbe20d7e0d2f8f",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0af47e5c98135e3c4",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-05-13T12:04:49.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-05-18T09:59:20.000Z",
-    "ImageId": "ami-004fac3d4533a2541",
-    "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-08ecb3a470135a7a6",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20220513-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-13T12:04:49.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-05-18T09:59:20.000Z",
+      "ImageId": "ami-004fac3d4533a2541",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-08ecb3a470135a7a6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-05-18T09:59:20.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-09-06T18:35:26.000Z",
-    "ImageId": "ami-0c93b29195d67a0ca",
-    "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-03283361ba297b0e6",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20220512-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-05-18T09:59:20.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-06T18:35:26.000Z",
+      "ImageId": "ami-0c93b29195d67a0ca",
+      "ImageLocation": "amazon/RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03283361ba297b0e6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-06T18:35:26.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-09-06T18:59:26.000Z",
-    "ImageId": "ami-06cc9ea389270405c",
-    "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0d87d9a3b83b8e663",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.6.0_HVM-20220503-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-06T18:35:26.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-06T18:59:26.000Z",
+      "ImageId": "ami-06cc9ea389270405c",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0d87d9a3b83b8e663",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-06T18:59:26.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-09-21T09:15:11.000Z",
-    "ImageId": "ami-0c82c5663e622b298",
-    "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0b1388bb0ec6eb24d",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM-20220513-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-06T18:59:26.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-09-21T09:15:11.000Z",
+      "ImageId": "ami-0c82c5663e622b298",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0b1388bb0ec6eb24d",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-21T09:15:11.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-09-21T09:49:54.000Z",
-    "ImageId": "ami-0228302bab05078b4",
-    "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a6951fc9c80e27d6",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM_BETA-20220829-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T09:15:11.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-21T09:49:54.000Z",
+      "ImageId": "ami-0228302bab05078b4",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a6951fc9c80e27d6",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-21T09:49:54.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-09-21T13:00:27.000Z",
-    "ImageId": "ami-09818359fcd692d8a",
-    "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-02c38351a829ac840",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM_BETA-20220829-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T09:49:54.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-09-21T13:00:27.000Z",
+      "ImageId": "ami-09818359fcd692d8a",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02c38351a829ac840",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-21T13:00:27.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-09-21T14:21:48.000Z",
-    "ImageId": "ami-04231e0f5229f26c7",
-    "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0a06b8043e120c7a1",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM_BETA-20220830-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T13:00:27.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-09-21T14:21:48.000Z",
+      "ImageId": "ami-04231e0f5229f26c7",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0a06b8043e120c7a1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-09-21T14:21:48.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-10-27T19:17:26.000Z",
-    "ImageId": "ami-038df2ec824c24e80",
-    "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-087fe6e4f12f9012a",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM_BETA-20220830-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-09-21T14:21:48.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-10-27T19:17:26.000Z",
+      "ImageId": "ami-038df2ec824c24e80",
+      "ImageLocation": "amazon/RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-087fe6e4f12f9012a",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-10-27T19:17:25.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-10-27T20:59:23.000Z",
-    "ImageId": "ami-045393c081cabeb1f",
-    "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0e3bdf826c29ba8f3",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-10-27T19:17:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-10-27T20:59:23.000Z",
+      "ImageId": "ami-045393c081cabeb1f",
+      "ImageLocation": "amazon/RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0e3bdf826c29ba8f3",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-10-27T20:59:23.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-01T20:07:41.000Z",
-    "ImageId": "ami-0d37ecbd75ec5a8c0",
-    "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0c8cbffd2b7600c8e",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-7.9_HVM-20221027-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-10-27T20:59:23.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-01T20:07:41.000Z",
+      "ImageId": "ami-0d37ecbd75ec5a8c0",
+      "ImageLocation": "amazon/RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0c8cbffd2b7600c8e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-01T20:07:41.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-11-01T20:35:25.000Z",
-    "ImageId": "ami-050c88925ffb2bb50",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-02159d201cbd2cdd2",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-01T20:07:41.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-01T20:35:25.000Z",
+      "ImageId": "ami-050c88925ffb2bb50",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02159d201cbd2cdd2",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-01T20:35:25.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-02T00:07:57.000Z",
-    "ImageId": "ami-05723c3b9cf4bf4ff",
-    "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-00cf19e582ba8f17c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20221027-arm64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-01T20:35:25.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-02T00:07:57.000Z",
+      "ImageId": "ami-05723c3b9cf4bf4ff",
+      "ImageLocation": "amazon/RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-00cf19e582ba8f17c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-02T00:07:56.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-03T16:14:44.000Z",
-    "ImageId": "ami-0176fddd9698c4c3a",
-    "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-010781f8f49062c57",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.0.0_HVM-20221027-x86_64-1-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-02T00:07:56.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T16:14:44.000Z",
+      "ImageId": "ami-0176fddd9698c4c3a",
+      "ImageLocation": "amazon/RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-010781f8f49062c57",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T16:14:44.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-03T18:01:07.000Z",
-    "ImageId": "ami-0bd7418456aaf76fb",
-    "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
-    "UsageOperation": "RunInstances:1010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0652c860378b3fce5",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T16:14:44.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T18:01:07.000Z",
+      "ImageId": "ami-0bd7418456aaf76fb",
+      "ImageLocation": "amazon/RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux with High Availability",
+      "UsageOperation": "RunInstances:1010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0652c860378b3fce5",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T18:01:07.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-03T18:37:50.000Z",
-    "ImageId": "ami-08e637cea2f053dfa",
-    "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-03d1ef09b8d87947c",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL_HA-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T18:01:07.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T18:37:50.000Z",
+      "ImageId": "ami-08e637cea2f053dfa",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-03d1ef09b8d87947c",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T18:37:50.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-11-03T19:23:02.000Z",
-    "ImageId": "ami-05c5c474dfb6af922",
-    "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-047275dadfd48c3b1",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM-20221101-x86_64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T18:37:50.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-03T19:23:02.000Z",
+      "ImageId": "ami-05c5c474dfb6af922",
+      "ImageLocation": "amazon/RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-047275dadfd48c3b1",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T19:23:02.000Z"
-  },
-  {
-    "Architecture": "x86_64",
-    "CreationDate": "2022-11-03T19:32:51.000Z",
-    "ImageId": "ami-0c08fd85d8f775888",
-    "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-02668108ddbc7146e",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-9.1.0_HVM-20221101-arm64-2-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:23:02.000Z"
+    },
+    {
+      "Architecture": "x86_64",
+      "CreationDate": "2022-11-03T19:32:51.000Z",
+      "ImageId": "ami-0c08fd85d8f775888",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-02668108ddbc7146e",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T19:32:51.000Z"
-  },
-  {
-    "Architecture": "arm64",
-    "CreationDate": "2022-11-03T19:46:03.000Z",
-    "ImageId": "ami-0a291b28b6d4b87fc",
-    "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-    "ImageType": "machine",
-    "Public": true,
-    "OwnerId": "309956199498",
-    "PlatformDetails": "Red Hat Enterprise Linux",
-    "UsageOperation": "RunInstances:0010",
-    "State": "available",
-    "BlockDeviceMappings": [
-      {
-        "DeviceName": "/dev/sda1",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "SnapshotId": "snap-0ace6060c23f7c01d",
-          "VolumeSize": 10,
-          "VolumeType": "gp2",
-          "Encrypted": false
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM-20221101-x86_64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:32:51.000Z"
+    },
+    {
+      "Architecture": "arm64",
+      "CreationDate": "2022-11-03T19:46:03.000Z",
+      "ImageId": "ami-0a291b28b6d4b87fc",
+      "ImageLocation": "amazon/RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+      "ImageType": "machine",
+      "Public": true,
+      "OwnerId": "309956199498",
+      "PlatformDetails": "Red Hat Enterprise Linux",
+      "UsageOperation": "RunInstances:0010",
+      "State": "available",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/sda1",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "SnapshotId": "snap-0ace6060c23f7c01d",
+            "VolumeSize": 10,
+            "VolumeType": "gp2",
+            "Encrypted": false
+          }
         }
-      }
-    ],
-    "Description": "Provided by Red Hat, Inc.",
-    "EnaSupport": true,
-    "Hypervisor": "xen",
-    "ImageOwnerAlias": "amazon",
-    "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
-    "RootDeviceName": "/dev/sda1",
-    "RootDeviceType": "ebs",
-    "SriovNetSupport": "simple",
-    "VirtualizationType": "hvm",
-    "DeprecationTime": "2024-11-03T19:46:03.000Z"
-  }
-]
+      ],
+      "Description": "Provided by Red Hat, Inc.",
+      "EnaSupport": true,
+      "Hypervisor": "xen",
+      "ImageOwnerAlias": "amazon",
+      "Name": "RHEL-8.7.0_HVM-20221101-arm64-0-Hourly2-GP2",
+      "RootDeviceName": "/dev/sda1",
+      "RootDeviceType": "ebs",
+      "SriovNetSupport": "simple",
+      "VirtualizationType": "hvm",
+      "DeprecationTime": "2024-11-03T19:46:03.000Z"
+    }
+  ]
+}

--- a/tests/update_images/testdata/update.sh
+++ b/tests/update_images/testdata/update.sh
@@ -9,5 +9,5 @@ gcloud compute images list --format="json" > google_list_images.json
 aws --region=us-east-1 ec2 describe-images \
     --owner 309956199498 \
     --filter "Name=is-public,Values=true" | \
-    jq '.Images | sort_by(.CreationDate)' \
+    jq '{ "Images": .Images | sort_by(.CreationDate)}' \
     > aws_list_images.json


### PR DESCRIPTION
Turns out the jq "sort_by()" method does not sort in place, it only returns the sorted array not the original JSON structure including the sorted array. Adding the missing Images key should fix our breaking e2e tests.

Changes:
Added missing JSON structure to jq sort
Recreated AWS test data using the modified script