### PR TITLE
Use UBI container in CI

### DIFF
--- a/.github/workflows/code_release.yaml
+++ b/.github/workflows/code_release.yaml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
 
       - name: Bootstrap poetry
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,10 @@
-FROM python:3.10-alpine
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 COPY ./dist/*.whl /opt/rhelocator/
 COPY ./data/image-data.json /opt/rhelocator/
 WORKDIR /opt/rhelocator
 
-RUN apk update \
-    && apk --no-cache --update add build-base
+RUN dnf -y install pip && dnf clean all
 
 RUN pip install ./*.whl
 


### PR DESCRIPTION
Internal deployments may need this packaged in a UBI container it should work well that way for external deployments, too.

Signed-off-by: Major Hayden <major@redhat.com>