### PR TITLE
Move mypy to pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,6 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Run mypy
-        run: poetry run mypy
-
       - name: Install pytest plugin
         run: poetry run pip install pytest-github-actions-annotate-failures
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,3 +83,11 @@ repos:
     rev: v2.21.0
     hooks:
       - id: validate_manifest
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.991'
+    hooks:
+      - id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports, src]
+        additional_dependencies:
+          - types-requests


### PR DESCRIPTION
This avoid long delays in GitHub actions while building out the types and it also avoids those situations where your pre-commit results look fine and then mypy explodes in the CI.

Signed-off-by: Major Hayden <major@redhat.com>