### PR TITLE
Reuse Azure access tokens

### DIFF
--- a/src/rhelocator/update_images/azure.py
+++ b/src/rhelocator/update_images/azure.py
@@ -7,16 +7,18 @@ import time
 from datetime import datetime
 
 import requests
-from requests import Timeout, TooManyRedirects, RequestException, HTTPError
+
+from requests import HTTPError
+from requests import RequestException
+from requests import TooManyRedirects
 
 from rhelocator import config
-from typing import Optional
 
-def post_request(url: str, data: dict[str, Optional[str]]) -> requests.Response:
+
+def post_request(url: str, data: dict[str, str | None]) -> requests.Response:
+    # TODO: "except Timeout:" and Log to console and return ""
     try:
         return requests.post(url, data, timeout=10)
-    # except Timeout:
-    # TODO: Log to console and return ""
     except (HTTPError, TooManyRedirects, RequestException) as err:
         raise SystemExit(err)
 
@@ -45,7 +47,7 @@ def get_access_token() -> str:
         time.sleep(config.AZURE_REQUEST_FAILURE_TIMEOUT)
 
     # If no auth token can be obtained, throw an exception.
-    raise Exception('Unable to authenticate.')
+    raise Exception("Unable to authenticate.")
 
 
 def get_locations(access_token: str) -> list[str]:
@@ -166,7 +168,12 @@ def get_skus(access_token: str, location: str, publisher: str, offer: str) -> li
 
 
 def get_image_versions(
-    access_token: str, location: str, publisher: str, offer: str, sku: str, latest: bool = True
+    access_token: str,
+    location: str,
+    publisher: str,
+    offer: str,
+    sku: str,
+    latest: bool = True,
 ) -> list[str]:
     """Get a list of Azure image versions.
 
@@ -263,7 +270,12 @@ def get_images() -> list[dict[str, str]]:
                         latest = False
                     # Get the image versions that match the pub/offer/sku combination.
                     image_versions = get_image_versions(
-                        access_token, config.AZURE_DEFAULT_LOCATION, publisher, offer, sku, latest
+                        access_token,
+                        config.AZURE_DEFAULT_LOCATION,
+                        publisher,
+                        offer,
+                        sku,
+                        latest,
                     )
 
                     # Loop through the image versions and add on this image version to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ MOCKED_AZURE_IMAGE_DETAILS = {
     }
 }
 
+MOCKED_AZURE_ACCESS_TOKEN = "access_token"
 
 def pytest_configure(config: any) -> None:
     config.addinivalue_line("markers", "e2e: mark as end-to-end test.")
@@ -96,6 +97,13 @@ def mock_aws_images(mocker):
     """Provide an offline result for calls to get_aws_images."""
     mock = mocker.patch("rhelocator.update_images.aws.describe_images")
     mock.return_value = MOCKED_AWS_IMAGE_LIST
+    return mock
+
+@pytest.fixture
+def mock_azure_access_token(mocker):
+    """Provide an offline result got get_azure_image_versions."""
+    mock = mocker.patch("rhelocator.update_images.azure.get_access_token")
+    mock.return_value = MOCKED_AZURE_ACCESS_TOKEN
     return mock
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ MOCKED_AZURE_IMAGE_DETAILS = {
 
 MOCKED_AZURE_ACCESS_TOKEN = "access_token"
 
+
 def pytest_configure(config: any) -> None:
     config.addinivalue_line("markers", "e2e: mark as end-to-end test.")
 
@@ -98,6 +99,7 @@ def mock_aws_images(mocker):
     mock = mocker.patch("rhelocator.update_images.aws.describe_images")
     mock.return_value = MOCKED_AWS_IMAGE_LIST
     return mock
+
 
 @pytest.fixture
 def mock_azure_access_token(mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,10 +110,7 @@ def test_azure_images_live(runner):
 
 
 def test_azure_images_offline(
-    mock_azure_access_token,
-    mock_azure_image_versions,
-    mock_azure_image_details,
-    runner
+    mock_azure_access_token, mock_azure_image_versions, mock_azure_image_details, runner
 ):
     """Run a live test against the Azure API to get images via CLI."""
     result = runner.invoke(cli.azure_images)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,7 +110,10 @@ def test_azure_images_live(runner):
 
 
 def test_azure_images_offline(
-    mock_azure_image_versions, mock_azure_image_details, runner
+    mock_azure_access_token,
+    mock_azure_image_versions,
+    mock_azure_image_details,
+    runner
 ):
     """Run a live test against the Azure API to get images via CLI."""
     result = runner.invoke(cli.azure_images)

--- a/tests/update_images/test_azure.py
+++ b/tests/update_images/test_azure.py
@@ -60,7 +60,7 @@ def test_get_locations(mock_requests: MagicMock) -> None:
     # Fake the access token.
     with patch("rhelocator.update_images.azure.get_access_token") as mock_token:
         mock_token.return_value = "secrete"
-        regions = azure.get_locations()
+        regions = azure.get_locations("dummy_access_token")
 
     assert regions == ["eastus"]
 
@@ -80,7 +80,7 @@ def test_get_publishers(mock_get):
     mock_get.return_value = Mock(ok=True)
     mock_get.return_value.json.return_value = publisher_response
 
-    publishers = azure.get_publishers("eastus")
+    publishers = azure.get_publishers("dummy_access_token", "eastus")
     assert publishers == [publisher_response[0]["name"]]
 
 
@@ -99,7 +99,7 @@ def test_get_offers(mock_get):
     mock_get.return_value = Mock(ok=True)
     mock_get.return_value.json.return_value = offer_response
 
-    offers = azure.get_offers("eastus", "publisher")
+    offers = azure.get_offers("dummy_access_token", "eastus", "publisher")
     assert offers == [offer_response[0]["name"]]
 
 
@@ -118,7 +118,7 @@ def test_get_skus(mock_get):
     mock_get.return_value = Mock(ok=True)
     mock_get.return_value.json.return_value = sku_response
 
-    skus = azure.get_skus("eastus", "publisher", "offer")
+    skus = azure.get_skus("dummy_access_token", "eastus", "publisher", "offer")
     assert skus == [sku_response[0]["name"]]
 
 
@@ -156,12 +156,12 @@ def test_get_image_versions(mock_get):
     mock_get.return_value.json.return_value = image_versions_response
 
     # Try with the default where we only get the latest image.
-    image_versions = azure.get_image_versions("eastus", "publisher", "offer", "sku")
+    image_versions = azure.get_image_versions("dummy_access_token", "eastus", "publisher", "offer", "sku")
     assert image_versions == [image_versions_response[-1]["name"]]
 
     # Now try to get all of the images.
     image_versions = azure.get_image_versions(
-        "eastus", "publisher", "offer", "sku", latest=False
+        "dummy_access_token", "eastus", "publisher", "offer", "sku", latest=False
     )
     assert image_versions == [x["name"] for x in image_versions_response]
 
@@ -191,7 +191,7 @@ def test_get_image_details(mock_get):
     mock_get.return_value.json.return_value = image_details_response
 
     image_details = azure.get_image_details(
-        "eastus", "publisher", "offer", "sku", "version"
+        "dummy_access_token", "eastus", "publisher", "offer", "sku", "version"
     )
     assert (
         image_details["properties"]["architecture"]

--- a/tests/update_images/test_azure.py
+++ b/tests/update_images/test_azure.py
@@ -2,28 +2,27 @@
 from __future__ import annotations
 
 import json
-import pytest
-
-from jsonschema import ValidationError
-from requests import RequestException
 
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
+
+from jsonschema import ValidationError
+from requests import RequestException
+
 from rhelocator import config
 from rhelocator.update_images import azure
 from rhelocator.update_images import schema
+
 
 @patch("rhelocator.update_images.azure.requests.post")
 def test_get_access_token(mock_post: MagicMock) -> None:
     """Test retrieving Azure locations."""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {
-      "foo": "bar",
-      "access_token": "secrete"
-    }
+    mock_response.json.return_value = {"foo": "bar", "access_token": "secrete"}
     mock_post.return_value = mock_response
 
     access_token = azure.get_access_token()
@@ -36,17 +35,17 @@ def test_fail_to_get_access_token(mock_post: MagicMock) -> None:
     """Test retrieving Azure locations."""
     mock_response = MagicMock()
     mock_response.status_code = 400
-    mock_response.json.return_value = {
-      "foo": "bar",
-      "access_token": ""
-    }
+    mock_response.json.return_value = {"foo": "bar", "access_token": ""}
     mock_post.return_value = mock_response
 
     with pytest.raises(Exception, match=r"Unable to authenticate"):
         azure.get_access_token()
 
 
-@patch("rhelocator.update_images.azure.requests.post", side_effect=RequestException('Failed Request'))
+@patch(
+    "rhelocator.update_images.azure.requests.post",
+    side_effect=RequestException("Failed Request"),
+)
 def test_post_request_ambigious_request_error(mock_post: MagicMock) -> None:
     """Test executing safeguarded post request."""
 
@@ -184,7 +183,9 @@ def test_get_image_versions(mock_get):
     mock_get.return_value.json.return_value = image_versions_response
 
     # Try with the default where we only get the latest image.
-    image_versions = azure.get_image_versions("dummy_access_token", "eastus", "publisher", "offer", "sku")
+    image_versions = azure.get_image_versions(
+        "dummy_access_token", "eastus", "publisher", "offer", "sku"
+    )
     assert image_versions == [image_versions_response[-1]["name"]]
 
     # Now try to get all of the images.


### PR DESCRIPTION
**What has been changed?**
- Access_token generation has been moved to get_images method.
- Methods querying Azure endpoints now need to be supplied with a token as parameter.
- Moved post request to its own method.
- Raise SystemExit if request errors are caught that would otherwise limit the CLI functionality.

If your are okay with the modifications, the other API calls will be modified as well (in a follow up task).

Closes: #222 
