### PR TITLE
Reduce update_image_data frequency to once a week

### DIFF
--- a/.github/workflows/update_cloud_data.yaml
+++ b/.github/workflows/update_cloud_data.yaml
@@ -2,8 +2,8 @@
 name: Update-Job
 
 on:
-  schedule: # run at midnight
-    - cron: "0 0 * * *"
+  schedule: # run every sunday at midnight
+    - cron: "0 0 * * 0"
 
 jobs:
   update-testdata:


### PR DESCRIPTION
As image updates don't happen that frequently and the cached data is only used for testing, I've reduced the frequency with which we update our local image data to once a week.