### PR TITLE
actions: Install poetry via pipx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,7 @@ jobs:
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
       - name: Bootstrap poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python - -y
+        run: pipx install poetry
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}


### PR DESCRIPTION
Remove the curl installation method for poetry and use pipx instead for a cleaner, more secure installation process. I should have been in less of a hurry when I originally committed this.

Signed-off-by: Major Hayden <major@redhat.com>