### PR TITLE
Enable automerge for renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,24 @@
   "extends": [
     "config:base"
   ],
-  "rangeStrategy": "update-lockfile",
+  "rangeStrategy": "bump",
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
If lock file updates are needed, renovate will propose a PR and instruct github to automatically merge the PR when tests pass. Also, any minor package updates will be auto-merged unless they change a major version.

Change the update strategy to "bump" so we can be more specific about the versions we use.

Signed-off-by: Major Hayden <major@redhat.com>