### PR TITLE
Remove yesqa/flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,24 +26,6 @@ repos:
       - id: python-use-type-annotations
       - id: python-check-blanket-noqa
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-        additional_dependencies: &flake8_deps
-          - flake8-broken-line==0.5.0
-          - flake8-bugbear==22.7.1
-          - flake8-comprehensions==3.10.0
-          - flake8-eradicate==1.3.0
-          - flake8-quotes==3.3.1
-          - flake8-simplify==0.19.3
-          - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==2.1.2
-          - flake8-typing-imports==1.12.0
-          - flake8-use-fstring==1.4
-          - pep8-naming==0.13.1
-          - flake8-pie==0.16.0
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:
@@ -72,12 +54,6 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        additional_dependencies: *flake8_deps
 
   - repo: https://github.com/pre-commit/pre-commit
     rev: v3.0.3


### PR DESCRIPTION
We keep having issues getting flake8 up to version 6 and it appears that many of the extra flake8 modules used by yesqa have conflicts with it. Also, some of those modules aren't maintained frequently.

Let's remove both and rely on black/isort/mypy/pycln to keep us linted.

Signed-off-by: Major Hayden <major@redhat.com>